### PR TITLE
Feat: HCS-2 Advanced Topic Registries

### DIFF
--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -53,12 +53,13 @@ The registry should adopt a standardized format to ensure consistent access and 
 
 A memo system is defined for indexers and browsers to understand the data's state and interpret it accordingly. The memo format follows:
 
-`[protocol_standard]:[indexed]`
+`[protocol_standard]:[indexed]:[ttl]`
 
 | Field     | Description                                                        | Example Value          |
 |-----------|--------------------------------------------------------------------|------------------------|
 | `protocol_standard`       | Protocol used by the registry, `hcs-2` for this standard.| `hcs-2`                |
 | `indexed`     | enum value of if all messages need pulled down or only the last / newest message | `0`           |
+| `ttl`               | a numeric value, representing the number of seconds which external infrastructure can use to determine how long messages in this registry should be stored in cache | `60`
 
 
 | Indexed enum     | Description                                                       
@@ -95,6 +96,10 @@ Examples:
 - Expectation for new records to be continually added.
 - Indexers should gather `only the last message` and metadata in that message will determine the protocol and execution. 
 - Processing state should start from the first message and proceed to the last sequential message number.
+
+## TTL Use Cases
+
+External infrastructure, dApps, clients should utilize the TTL as a reference point for how long to cache data, before attempting to fetch new messages from the registry. The default suggested value is 86400 (one day). Certain use cases might opt for lower or higher TTL values. For scalability, it is imperative to pick values that make the most sense. 
 
 
 ### Use Cases and Functionalities
@@ -196,6 +201,7 @@ Each field within the JSON structure for the `register`, `delete`, and `update` 
 - **`t_id` (Topic ID)**: Should match the Hedera account ID format, which is three groups of numbers separated by periods (e.g., `0.0.123456`).
 - **`uid` (Unique Identifier)**: Must be a valid sequence number or unique identifier relevant to the operation.
 - **`m` (Memo)**: An optional field providing additional context or information. Limited to 500 characters.
+- **`ttl`**: An optional field providing an override to the TTL in the memo. Typically not required. 
 
 ### Attributes Validation
 

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -12,9 +12,11 @@
   - [Motivation](#motivation)
   - [Specification](#specification)
 
-## Authors
-- Kantorcodes [https://twitter.com/kantorcodes]()
+## Primary Author
 - Patches [https://twitter.com/TMCC_Patches]()
+
+## Additional Authors
+- Kantorcodes [https://twitter.com/kantorcodes]()
 
 ## Abstract
 
@@ -56,21 +58,39 @@ A memo system is defined for indexers and browsers to understand the data's stat
 | Field     | Description                                                        | Example Value          |
 |-----------|--------------------------------------------------------------------|------------------------|
 | `protocol_standard`       | Protocol used by the registry, `hcs-2` for this standard.| `hcs-2`                |
-| `indexed`     | Boolean value of if all messages need pulled down or only the last / newest message | `true`           |
+| `indexed`     | enum value of if all messages need pulled down or only the last / newest message | `0`           |
+
+
+| Indexed enum     | Description                                                       
+|-----------|-------------------------------------------------------------------------------------------|
+| `0`       | The topic id is indexed, and all messages should be read
+| `1`     | The topic id is not indexed, and only the last message should be used to determine state / topic data
 
 
 ### Example Memo Format
 
-`hcs-2:true`
+`hcs-2:0`
 
-### Indexed Registry Mechanics
+### Indexed Registry Mechanics [enum: 0]
+Uses:
+Topic ids used for registiers where you need all records to get the data you need to execute logic. Typically good for most registeries. 
+
+Examples:
+1. User registry for profiles of a video game
+2. A registry for posts on a social media site for a specific user
 
 - Expectation for new records to be continually added.
 - Indexers should gather all files and metadata listed in the registry.
 - Processing state should start from the first message and proceed to the last sequential message number.
 
 
-### Non-Indexed Registry Mechanics
+### Non-Indexed Registry Mechanics [enum: 1]
+Uses:
+Topic ids used for dynamic state of an entity. The latest message being used is the current state of the entity being defined
+
+Examples:
+1. A description for a product on a ecom site
+2. A state of an NFT for a video game 
 
 - Expectation for new records to be continually added.
 - Indexers should gather `only the last message` and metadata in that message will determine the protocol and execution. 
@@ -106,6 +126,17 @@ Register new entries or versions to the registry using the following JSON struct
 }
 ```
 
+example useage:
+```json
+{
+  "p": "hcs-2",
+  "op": "register",
+  "t_id": "0.0.123456",
+  "metadata": "hcs://1/0.0.456789",
+  "m": "register t",
+}
+```
+
 #### Delete
 
 Remove entries based on UID or sequence number of the message on the topic id
@@ -116,6 +147,16 @@ Remove entries based on UID or sequence number of the message on the topic id
   "op": "delete",
   "uid": "SEQUENCE_NUMBER_OF_REGISTER_MESSAGE_TO_DELETE",
   "m": "OPTIONAL_MEMO"
+}
+```
+
+example usage:
+```json
+{
+  "p": "hcs-2",
+  "op": "delete",
+  "uid": "33",
+  "m": "remove hashsite from users bookmark"
 }
 ```
 
@@ -134,6 +175,18 @@ Modify existing entries, completed by updating the uid or sequence number and up
 }
 ```
 
+example usage:
+```json
+{
+  "p": "hcs-2",
+  "op": "update",
+  "uid": "60",
+  "t_id": "0.0.123456",
+  "metadata": "hcs://1/0.0.456789",
+  "m": "update sequence number 60 to a new topic id and metadata"
+}
+```
+
 ## Validation
 
 Each field within the JSON structure for the `register`, `delete`, and `update` operations must meet specific criteria to be considered valid:
@@ -148,3 +201,6 @@ Each field within the JSON structure for the `register`, `delete`, and `update` 
 
 Specific validation rules for each attribute ensure that users adhere to the format and standards expected within the HCS framework, enhancing interoperability and consistency.
 
+### Conclusion
+
+HCS-2 creates a method of connecting data and enabling dynamic state registries 

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -12,10 +12,12 @@
   - [Motivation](#motivation)
   - [Specification](#specification)
 
-## Primary Author
+## Authors
+ 
+### Primary Author
 - Patches [https://twitter.com/TMCC_Patches]()
 
-## Additional Authors
+### Additional Authors
 - Kantorcodes [https://twitter.com/kantorcodes]()
 
 ## Abstract
@@ -44,10 +46,95 @@ The registry should adopt a standardized format to ensure consistent access and 
 
 ### Operations
 
-- **Register**: Adds new entries or versions to the registry.
-- **Delete**: Removes entries based on UID.
-- **Update**: Modifies existing entries, by changing the referenced sequence number and updating the t_id and metadata pointers.
+| Operation     | Description                                                        | Usable in non-indexed topic          |
+|-----------|--------------------------------------------------------------------|------------------------|
+| `Register` | Adds new entries or versions to the registry.| ✅              |
+| `Delete`  | Removes entries based on UID.               | ❌             |
+| `Update`  | Modifies existing entries, by changing the referenced sequence number and updating the t_id and metadata pointers  | ❌         |
 
+
+#### Register
+
+Registration allows creating additional entries / versions to the Topic. Utilize the follow JSON structure for valid messages.
+
+```json
+{
+  "p": "hcs-2",
+  "op": "register",
+  "t_id": "TOPIC_ID_TO_REGISTER",
+  "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
+  "m": "OPTIONAL_MEMO",
+}
+```
+
+example useage:
+```json
+{
+  "p": "hcs-2",
+  "op": "register",
+  "t_id": "0.0.123456",
+  "metadata": "hcs://1/0.0.456789",
+  "m": "register t",
+}
+```
+
+#### Delete
+
+Remove entries based on UID or sequence number of the message on the topic id. 
+
+**This operation is invalid for non-indexed topics**
+
+Use the following JSON structure:
+
+```json
+{
+  "p": "hcs-2",
+  "op": "delete",
+  "uid": "SEQUENCE_NUMBER_OF_REGISTER_MESSAGE_TO_DELETE",
+  "m": "OPTIONAL_MEMO"
+}
+```
+
+example usage:
+```json
+{
+  "p": "hcs-2",
+  "op": "delete",
+  "uid": "33",
+  "m": "remove hashsite from users bookmark"
+}
+```
+
+#### Update
+
+Modify existing entries, completed by updating the uid or sequence number and updating that record with new metadata. 
+
+**This operation is invalid for non-indexed topics**
+
+Use the following JSON structure:
+
+```json
+{
+  "p": "hcs-2",
+  "op": "update",
+  "uid": "SEQUENCE_NUMBER_OF_REGISTER_MESSAGE_TO_UPDATE",
+  "t_id": "NEW_TOPIC_ID_TO_REGISTER",
+  "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
+  "m": "OPTIONAL_MEMO"
+}
+```
+
+example usage:
+```json
+{
+  "p": "hcs-2",
+  "op": "update",
+  "uid": "60",
+  "t_id": "0.0.123456",
+  "metadata": "hcs://1/0.0.456789",
+  "m": "update sequence number 60 to a new topic id and metadata"
+}
+```
 
 ### Memo for Indexers and Browsers
 
@@ -117,87 +204,12 @@ Registry links should follow a consistent format to ensure easy access and inter
 This facilitates direct access to specific registry entries and simplifies integration with external systems and applications.
 
 
-#### Register
-
-Register new entries or versions to the registry using the following JSON structure:
-
-```json
-{
-  "p": "hcs-2",
-  "op": "register",
-  "t_id": "TOPIC_ID_TO_REGISTER",
-  "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
-  "m": "OPTIONAL_MEMO",
-}
-```
-
-example useage:
-```json
-{
-  "p": "hcs-2",
-  "op": "register",
-  "t_id": "0.0.123456",
-  "metadata": "hcs://1/0.0.456789",
-  "m": "register t",
-}
-```
-
-#### Delete
-
-Remove entries based on UID or sequence number of the message on the topic id
-
-```json
-{
-  "p": "hcs-2",
-  "op": "delete",
-  "uid": "SEQUENCE_NUMBER_OF_REGISTER_MESSAGE_TO_DELETE",
-  "m": "OPTIONAL_MEMO"
-}
-```
-
-example usage:
-```json
-{
-  "p": "hcs-2",
-  "op": "delete",
-  "uid": "33",
-  "m": "remove hashsite from users bookmark"
-}
-```
-
-#### Update
-
-Modify existing entries, completed by updating the uid or sequence number and updating that record with new metadata. Use the following JSON structure:
-
-```json
-{
-  "p": "hcs-2",
-  "op": "update",
-  "uid": "SEQUENCE_NUMBER_OF_REGISTER_MESSAGE_TO_UPDATE",
-  "t_id": "NEW_TOPIC_ID_TO_REGISTER",
-  "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
-  "m": "OPTIONAL_MEMO"
-}
-```
-
-example usage:
-```json
-{
-  "p": "hcs-2",
-  "op": "update",
-  "uid": "60",
-  "t_id": "0.0.123456",
-  "metadata": "hcs://1/0.0.456789",
-  "m": "update sequence number 60 to a new topic id and metadata"
-}
-```
-
 ## Validation
 
 Each field within the JSON structure for the `register`, `delete`, and `update` operations must meet specific criteria to be considered valid:
 
 - **`p` (Protocol)**: Must be a string matching `hcs-2`. This validates that the entry adheres to the current standard.
-- **`op` (Operation)**: Must be one of `register`, `delete`, or `update`. This indicates the action being performed.
+- **`op` (Operation)**: Must be one of `register`, `delete`, or `update`. This indicates the action being performed. Note, `update` and `delete` would not be valid or needed operations for a `non-indexed` topic. 
 - **`t_id` (Topic ID)**: Should match the Hedera account ID format, which is three groups of numbers separated by periods (e.g., `0.0.123456`).
 - **`uid` (Unique Identifier)**: Must be a valid sequence number or unique identifier relevant to the operation.
 - **`m` (Memo)**: An optional field providing additional context or information. Limited to 500 characters.

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -157,7 +157,7 @@ A memo system is defined for indexers and browsers to understand the data's stat
 
 ### Example Memo Format
 
-`hcs-2:0`
+`hcs-2:0:60`
 
 ### Indexed Registry Mechanics [enum: 0]
 Uses:

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -44,7 +44,7 @@ The registry should adopt a standardized format to ensure consistent access and 
 
 - **Register**: Adds new entries or versions to the registry.
 - **Delete**: Removes entries based on UID.
-- **Update**: Modifies existing entries, typically by incrementing the serial number and updating the metadata.
+- **Update**: Modifies existing entries, by changing the referenced serial number and updating the t_id and metadata pointers.
 
 
 ### Memo for Indexers and Browsers
@@ -56,7 +56,12 @@ A memo system is defined for indexers and browsers to understand the data's stat
 | Field     | Description                                                        | Example Value          |
 |-----------|--------------------------------------------------------------------|------------------------|
 | `protocol_standard`       | Protocol used by the registry, `hcs-2` for this standard.| `hcs-2`                |
-| `indexed`     | Boolean value of if all messages need pulled down or only the last / newwest message | `true`           |
+| `indexed`     | Boolean value of if all messages need pulled down or only the last / newest message | `true`           |
+
+
+### Example Memo Format
+
+`hcs-2:true`
 
 ### Indexed Registry Mechanics
 
@@ -126,59 +131,6 @@ Modify existing entries, completed by updating the uid or sequence number and up
   "t_id": "NEW_TOPIC_ID_TO_REGISTER",
   "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
   "m": "OPTIONAL_MEMO"
-}
-```
-
-### Memo for Indexers and Browsers
-
-This standard also introduces a memo system for indexers and browsers to understand the data's state and interpret it accordingly. The memo format follows:
-
-`[protocol_standard]:[indexed]`
-
-### Example Memo Format
-
-`hcs-2:true`
-
-
-
-### Example HRL Format
-
-Registry links should follow a consistent format to ensure easy access and interpretation:
-
-`hcs://2/{topic_id}`
-
-This facilitates direct access to specific registry entries and simplifies integration with external systems and applications.
-
-## Examples of Usage
-
-This section provides detailed examples of how the `register`, `delete`, and `update` operations can be used in practice, aligning with the HCS-2 standard's goals and mechanisms.
-
-### Register Operation Example
-
-To register a new topic in the Topic Registry:
-
-```json
-{
-  "p": "hcs-20",
-  "op": "register",
-  "name": "MyFirstTopic",
-  "metadata": "hcs://1/0.0.123456",
-  "t_id": "0.0.9876543",
-  "m": "Initial registration of MyFirstTopic"
-}
-```
-
-### Update Operation Example
-
-To update an existing topic in the Topic Registry:
-
-```json
-{
-  "p": "hcs-2",
-  "op": "update",
-  "uid": "45",
-  "t_id": "new_topic_id",
-  "m": "Updated to reflect changes in documentation and structure."
 }
 ```
 

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -8,9 +8,27 @@
     - [Status: Draft](#status-draft)
     - [Table of Contents](#table-of-contents)
   - [Authors](#authors)
+    - [Primary Author](#primary-author)
+    - [Additional Authors](#additional-authors)
   - [Abstract](#abstract)
   - [Motivation](#motivation)
   - [Specification](#specification)
+    - [Registry Format and Usage](#registry-format-and-usage)
+    - [Operations](#operations)
+      - [Register](#register)
+      - [Delete](#delete)
+      - [Update](#update)
+      - [Migrate](#migrate)
+    - [Memo for Indexers and Browsers](#memo-for-indexers-and-browsers)
+    - [Example Memo Format](#example-memo-format)
+    - [Indexed Registry Mechanics \[enum: 0\]](#indexed-registry-mechanics-enum-0)
+    - [Non-Indexed Registry Mechanics \[enum: 1\]](#non-indexed-registry-mechanics-enum-1)
+  - [TTL Use Cases](#ttl-use-cases)
+    - [Use Cases and Functionalities](#use-cases-and-functionalities)
+    - [Example URI Format](#example-uri-format)
+  - [Validation](#validation)
+    - [Attributes Validation](#attributes-validation)
+    - [Conclusion](#conclusion)
 
 ## Authors
  
@@ -48,7 +66,8 @@ The registry should adopt a standardized format to ensure consistent access and 
 
 | Operation     | Description                                                        | Usable in non-indexed topic          |
 |-----------|--------------------------------------------------------------------|------------------------|
-| `Register` | Adds new entries or versions to the registry.| ✅              |
+| `Register` | Adds new entries or versions to the registry.| ✅   
+| `Migrate`  | Moves messages to a new Topic ID. Previous messages are invalidated and new state is computed from the new Topic.  | ✅         |           |
 | `Delete`  | Removes entries based on UID.               | ❌             |
 | `Update`  | Modifies existing entries, by changing the referenced sequence number and updating the t_id and metadata pointers  | ❌         |
 
@@ -133,6 +152,33 @@ example usage:
   "t_id": "0.0.123456",
   "metadata": "hcs://1/0.0.456789",
   "m": "update sequence number 60 to a new topic id and metadata"
+}
+```
+
+#### Migrate
+
+This operation is irreversible, and can only exist once within a Topic Id. New messages after a `migrate` operation are invalid. All HRLs pointing to this Topic ID, should use the new Topic Id to compute state.
+
+Use the following JSON structure:
+
+```json
+{
+  "p": "hcs-2",
+  "op": "migrate",
+  "t_id": "NEW_TOPIC_ID_TO_MIGRATE_TO",
+  "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
+  "m": "OPTIONAL_MEMO"
+}
+```
+
+example usage:
+```json
+{
+  "p": "hcs-2",
+  "op": "migrate",
+  "t_id": "0.0.123456",
+  "metadata": "hcs://1/0.0.456789",
+  "m": "All hope is lost. We're moving on."
 }
 ```
 

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -31,7 +31,7 @@
     - [Conclusion](#conclusion)
 
 ## Authors
- 
+
 ### Primary Author
 - Patches [https://twitter.com/TMCC_Patches]()
 
@@ -60,13 +60,13 @@ The registry should adopt a standardized format to ensure consistent access and 
 | `uid`     | Sequence number for files or states within the registry.         | `42`            |
 | `m`       | Optional metadata providing additional context.                    | `Update for Q2 release`|
 
-`m` - memo is restricted to 500 charcters 
+`m` - memo is restricted to 500 characters
 
 ### Operations
 
 | Operation     | Description                                                        | Usable in non-indexed topic          |
 |-----------|--------------------------------------------------------------------|------------------------|
-| `Register` | Adds new entries or versions to the registry.| ✅   
+| `Register` | Adds new entries or versions to the registry.| ✅
 | `Migrate`  | Moves messages to a new Topic ID. Previous messages are invalidated and new state is computed from the new Topic.  | ✅         |           |
 | `Delete`  | Removes entries based on UID.               | ❌             |
 | `Update`  | Modifies existing entries, by changing the referenced sequence number and updating the t_id and metadata pointers  | ❌         |
@@ -99,7 +99,7 @@ example useage:
 
 #### Delete
 
-Remove entries based on UID or sequence number of the message on the topic id. 
+Remove entries based on UID or sequence number of the message on the topic id.
 
 **This operation is invalid for non-indexed topics**
 
@@ -126,7 +126,7 @@ example usage:
 
 #### Update
 
-Modify existing entries, completed by updating the uid or sequence number and updating that record with new metadata. 
+Modify existing entries, completed by updating the uid or sequence number and updating that record with new metadata.
 
 **This operation is invalid for non-indexed topics**
 
@@ -195,7 +195,7 @@ A memo system is defined for indexers and browsers to understand the data's stat
 | `ttl`               | a numeric value, representing the number of seconds which external infrastructure can use to determine how long messages in this registry should be stored in cache | `60`
 
 
-| Indexed enum     | Description                                                       
+| Indexed enum     | Description
 |-----------|-------------------------------------------------------------------------------------------|
 | `0`       | The topic id is indexed, and all messages should be read
 | `1`     | The topic id is not indexed, and only the last message should be used to determine state / topic data
@@ -207,7 +207,7 @@ A memo system is defined for indexers and browsers to understand the data's stat
 
 ### Indexed Registry Mechanics [enum: 0]
 Uses:
-Topic ids used for registiers where you need all records to get the data you need to execute logic. Typically good for most registeries. 
+Topic ids used for registiers where you need all records to get the data you need to execute logic. Typically good for most registeries.
 
 Examples:
 1. User registry for profiles of a video game
@@ -224,15 +224,15 @@ Topic ids used for dynamic state of an entity. The latest message being used is 
 
 Examples:
 1. A description for a product on a ecom site
-2. A state of an NFT for a video game 
+2. A state of an NFT for a video game
 
 - Expectation for new records to be continually added.
-- Indexers should gather `only the last message` and metadata in that message will determine the protocol and execution. 
+- Indexers should gather `only the last message` and metadata in that message will determine the protocol and execution.
 - Processing state should start from the first message and proceed to the last sequential message number.
 
 ## TTL Use Cases
 
-External infrastructure, dApps, clients should utilize the TTL as a reference point for how long to cache data, before attempting to fetch new messages from the registry. The default suggested value is 86400 (one day). Certain use cases might opt for lower or higher TTL values. For scalability, it is imperative to pick values that make the most sense. 
+External infrastructure, dApps, clients should utilize the TTL as a reference point for how long to cache data, before attempting to fetch new messages from the registry. The default suggested value is 86400 (one day). Certain use cases might opt for lower or higher TTL values. For scalability, it is imperative to pick values that make the most sense.
 
 
 ### Use Cases and Functionalities
@@ -255,11 +255,11 @@ This facilitates direct access to specific registry entries and simplifies integ
 Each field within the JSON structure for the `register`, `delete`, and `update` operations must meet specific criteria to be considered valid:
 
 - **`p` (Protocol)**: Must be a string matching `hcs-2`. This validates that the entry adheres to the current standard.
-- **`op` (Operation)**: Must be one of `register`, `delete`, or `update`. This indicates the action being performed. Note, `update` and `delete` would not be valid or needed operations for a `non-indexed` topic. 
+- **`op` (Operation)**: Must be one of `register`, `delete`, or `update`. This indicates the action being performed. Note, `update` and `delete` would not be valid or needed operations for a `non-indexed` topic.
 - **`t_id` (Topic ID)**: Should match the Hedera account ID format, which is three groups of numbers separated by periods (e.g., `0.0.123456`).
 - **`uid` (Unique Identifier)**: Must be a valid sequence number or unique identifier relevant to the operation.
 - **`m` (Memo)**: An optional field providing additional context or information. Limited to 500 characters.
-- **`ttl`**: An optional field providing an override to the TTL in the memo. Typically not required. 
+- **`ttl`**: An optional field providing an override to the TTL in the memo. Typically not required.
 
 ### Attributes Validation
 
@@ -267,4 +267,4 @@ Specific validation rules for each attribute ensure that users adhere to the for
 
 ### Conclusion
 
-HCS-2 creates a method of connecting data and enabling dynamic state registries 
+HCS-2 creates a method of connecting data and enabling dynamic state registries

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -44,7 +44,7 @@ The registry should adopt a standardized format to ensure consistent access and 
 
 - **Register**: Adds new entries or versions to the registry.
 - **Delete**: Removes entries based on UID.
-- **Update**: Modifies existing entries, by changing the referenced serial number and updating the t_id and metadata pointers.
+- **Update**: Modifies existing entries, by changing the referenced sequence number and updating the t_id and metadata pointers.
 
 
 ### Memo for Indexers and Browsers

--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -1,14 +1,10 @@
----
-description: This specification provides a standard way to create a new registry for a sub-standard like HCS-1.
----
-
-# HCS-2 Standard: Topic Registries
+# HCS-2 Standard: Advanced Topic Registries
 
 ### Status: Draft
 
 ### Table of Contents
 
-- [HCS-2 Standard: Topic Registries](#hcs-2-standard-topic-registries)
+- [HCS-2 Standard: Advanced Topic Registries](#hcs-2-standard-advanced-topic-registries)
     - [Status: Draft](#status-draft)
     - [Table of Contents](#table-of-contents)
   - [Authors](#authors)
@@ -22,10 +18,181 @@ description: This specification provides a standard way to create a new registry
 
 ## Abstract
 
-This specification provides a standard way to group Topic IDs that follow a particular standard into a single Topic for finding all related data.
+This standard introduces advanced methodologies for managing and interacting with Topic Registries within the HCS framework. It focuses on enabling dynamic metadata, versioning, and comprehensive file management through unique identifiers and protocols.
 
 ## Motivation
 
-Downstream clients would like an easy way to consume and identify related data in a standardized format.
+The advent of dynamic metadata and the need for detailed version histories and state management in decentralized environments have necessitated the development of more sophisticated Topic Registries. This standard aims to provide a robust framework for indexing, retrieving, and interpreting diverse data types, enhancing the utility and scalability of NFTs, and facilitating advanced web functionalities like full site recursion.
 
 ## Specification
+
+### Registry Format and Usage
+
+The registry should adopt a standardized format to ensure consistent access and interpretation. The following fields are introduced:
+
+| Field     | Description                                                        | Example Value          |
+|-----------|--------------------------------------------------------------------|------------------------|
+| `p`       | Protocol used by the registry, typically `hcs-2` for this standard.| `hcs-2`                |
+| `op`      | Operation being executed (register, delete, update).               | `register`             |
+| `t_id`    | Topic ID where the registry information is stored.                 | `0.0.1234567`          |
+| `uid`     | Sequence number for files or states within the registry.         | `42`            |
+| `m`       | Optional metadata providing additional context.                    | `Update for Q2 release`|
+
+`m` - memo is restricted to 500 charcters 
+
+### Operations
+
+- **Register**: Adds new entries or versions to the registry.
+- **Delete**: Removes entries based on UID.
+- **Update**: Modifies existing entries, typically by incrementing the serial number and updating the metadata.
+
+
+### Memo for Indexers and Browsers
+
+A memo system is defined for indexers and browsers to understand the data's state and interpret it accordingly. The memo format follows:
+
+`[protocol_standard]:[indexed]`
+
+| Field     | Description                                                        | Example Value          |
+|-----------|--------------------------------------------------------------------|------------------------|
+| `protocol_standard`       | Protocol used by the registry, `hcs-2` for this standard.| `hcs-2`                |
+| `indexed`     | Boolean value of if all messages need pulled down or only the last / newwest message | `true`           |
+
+### Indexed Registry Mechanics
+
+- Expectation for new records to be continually added.
+- Indexers should gather all files and metadata listed in the registry.
+- Processing state should start from the first message and proceed to the last sequential message number.
+
+
+### Non-Indexed Registry Mechanics
+
+- Expectation for new records to be continually added.
+- Indexers should gather `only the last message` and metadata in that message will determine the protocol and execution. 
+- Processing state should start from the first message and proceed to the last sequential message number.
+
+
+### Use Cases and Functionalities
+
+- Dynamic metadata enables NFTs and other assets to reflect changes and updates over time.
+- Full version history allows for a complete understanding of an item's evolution.
+- Enhanced file and website management through recursive indexing and state awareness.
+
+### Example URI Format
+
+Registry links should follow a consistent format to ensure easy access and interpretation:
+
+`hcs://2/{topic_id}`
+
+This facilitates direct access to specific registry entries and simplifies integration with external systems and applications.
+
+
+#### Register
+
+Register new entries or versions to the registry using the following JSON structure:
+
+```json
+{
+  "p": "hcs-2",
+  "op": "register",
+  "t_id": "TOPIC_ID_TO_REGISTER",
+  "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
+  "m": "OPTIONAL_MEMO",
+}
+```
+
+#### Delete
+
+Remove entries based on UID or sequence number of the message on the topic id
+
+```json
+{
+  "p": "hcs-2",
+  "op": "delete",
+  "uid": "SEQUENCE_NUMBER_OF_REGISTER_MESSAGE_TO_DELETE",
+  "m": "OPTIONAL_MEMO"
+}
+```
+
+#### Update
+
+Modify existing entries, completed by updating the uid or sequence number and updating that record with new metadata. Use the following JSON structure:
+
+```json
+{
+  "p": "hcs-2",
+  "op": "update",
+  "uid": "SEQUENCE_NUMBER_OF_REGISTER_MESSAGE_TO_UPDATE",
+  "t_id": "NEW_TOPIC_ID_TO_REGISTER",
+  "metadata": "OPTIONAL_METADATA (HIP-412 compliant)",
+  "m": "OPTIONAL_MEMO"
+}
+```
+
+### Memo for Indexers and Browsers
+
+This standard also introduces a memo system for indexers and browsers to understand the data's state and interpret it accordingly. The memo format follows:
+
+`[protocol_standard]:[indexed]`
+
+### Example Memo Format
+
+`hcs-2:true`
+
+
+
+### Example HRL Format
+
+Registry links should follow a consistent format to ensure easy access and interpretation:
+
+`hcs://2/{topic_id}`
+
+This facilitates direct access to specific registry entries and simplifies integration with external systems and applications.
+
+## Examples of Usage
+
+This section provides detailed examples of how the `register`, `delete`, and `update` operations can be used in practice, aligning with the HCS-2 standard's goals and mechanisms.
+
+### Register Operation Example
+
+To register a new topic in the Topic Registry:
+
+```json
+{
+  "p": "hcs-20",
+  "op": "register",
+  "name": "MyFirstTopic",
+  "metadata": "hcs://1/0.0.123456",
+  "t_id": "0.0.9876543",
+  "m": "Initial registration of MyFirstTopic"
+}
+```
+
+### Update Operation Example
+
+To update an existing topic in the Topic Registry:
+
+```json
+{
+  "p": "hcs-2",
+  "op": "update",
+  "uid": "45",
+  "t_id": "new_topic_id",
+  "m": "Updated to reflect changes in documentation and structure."
+}
+```
+
+## Validation
+
+Each field within the JSON structure for the `register`, `delete`, and `update` operations must meet specific criteria to be considered valid:
+
+- **`p` (Protocol)**: Must be a string matching `hcs-2`. This validates that the entry adheres to the current standard.
+- **`op` (Operation)**: Must be one of `register`, `delete`, or `update`. This indicates the action being performed.
+- **`t_id` (Topic ID)**: Should match the Hedera account ID format, which is three groups of numbers separated by periods (e.g., `0.0.123456`).
+- **`uid` (Unique Identifier)**: Must be a valid sequence number or unique identifier relevant to the operation.
+- **`m` (Memo)**: An optional field providing additional context or information. Limited to 500 characters.
+
+### Attributes Validation
+
+Specific validation rules for each attribute ensure that users adhere to the format and standards expected within the HCS framework, enhancing interoperability and consistency.
+


### PR DESCRIPTION
Couple questions, but close to complete I think for a PR

t_id: Should this just be a topic id OR should we add hcs://1/ , hcs://2/ requirement and change to hrl?

I'm torn, one is more flexible and less fragile, while the other helps indexers know the protocol before digesting information.

Reasoning for t_id:
- Reading a topic memo is becoming a backbone element of standards, so it's ok to assume that the memo will have either the protocol memo or the hash (hcs-1) and then will have all the information like if it's indexed.
- lighter weight seems beneficial for ease of registries and lowers probability of incorrect data entry

Reasons against t_id:
- Higher costs on compute: Indexers must always execute another query for every registry message to grab the memo instead of loading all the messages to see if it's a file or a another registry or a logging topic id before executing the lookup memo query to digest the data. 


Thoughts?
