### PR TITLE
docs: expand AI Plugin Scanner library docs

### DIFF
--- a/docs/libraries/ai-plugin-scanner/guard/get-started.md
+++ b/docs/libraries/ai-plugin-scanner/guard/get-started.md
@@ -1,0 +1,145 @@
+---
+title: Guard get started
+sidebar_position: 2
+---
+
+# Guard get started
+
+Install `hol-guard` when you want local harness protection before Codex, Claude Code, Cursor, Gemini, or OpenCode launch new or changed tools.
+
+Guard is local-first. The core safety loop works before sign-in, before sync, and before any team policy is involved.
+
+## Install
+
+```bash
+pip install hol-guard
+```
+
+If you prefer isolated shell tools:
+
+```bash
+pipx install hol-guard
+```
+
+## The everyday flow
+
+1. Detect the harnesses Guard can manage on this machine.
+
+   ```bash
+   hol-guard bootstrap
+   ```
+
+2. Install Guard in front of the harness you use most.
+
+   ```bash
+   hol-guard install codex
+   ```
+
+3. Record a baseline once before you trust the current artifact set.
+
+   ```bash
+   hol-guard run codex --dry-run
+   ```
+
+4. Launch through Guard after that.
+
+   ```bash
+   hol-guard run codex
+   ```
+
+5. If Guard cannot pause inline, resolve the queued request in the local approval center.
+
+   ```bash
+   hol-guard approvals
+   ```
+
+6. Inspect receipts, diffs, and current managed state.
+
+   ```bash
+   hol-guard receipts
+   hol-guard status
+   hol-guard diff codex
+   ```
+
+## Fine-tune local policy
+
+Guard resolves decisions in this order:
+
+1. saved decisions from `hol-guard approvals`
+2. workspace override file
+3. home config
+4. Guard's built-in recommendation
+
+Home config example:
+
+```toml
+mode = "prompt"
+default_action = "warn"
+changed_hash_action = "require-reapproval"
+
+[harnesses.codex]
+default_action = "allow"
+
+[publishers.hashgraph-online]
+default_action = "allow"
+
+[artifacts."codex:project:workspace_tools"]
+default_action = "sandbox-required"
+```
+
+Workspace override example:
+
+```toml
+# .ai-plugin-scanner-guard.toml
+[artifacts."codex:project:workspace_tools"]
+default_action = "block"
+```
+
+Supported actions:
+
+- `allow`
+- `warn`
+- `block`
+- `sandbox-required`
+- `require-reapproval`
+
+## What `install` changes
+
+`hol-guard install <harness>` creates a local launcher shim under Guard's home directory:
+
+- macOS and Linux: `~/.config/.ai-plugin-scanner-guard/bin/guard-<harness>`
+- Windows: `~/.config/.ai-plugin-scanner-guard/bin/guard-<harness>.cmd`
+
+Claude Code also gets Guard hook entries in `.claude/settings.local.json` when you install from a workspace.
+
+## Approval paths
+
+Guard uses three approval tiers:
+
+1. native harness approval when the harness already has a strong permission model
+2. the local Guard approval center on `127.0.0.1`
+3. terminal resolution through `hol-guard approvals`
+
+Current strategy:
+
+- `claude-code` prefers Claude hooks and can defer blocked work cleanly
+- `codex` uses the Guard approval center today
+- `cursor` keeps Cursor's native tool approval and lets Guard own artifact trust
+- `opencode` keeps OpenCode's permission model and lets Guard manage package policy
+- `gemini` scans extension manifests and routes blocked changes to the approval center
+
+## Useful validation loop
+
+```bash
+hol-guard detect codex --json
+hol-guard install codex
+hol-guard status
+hol-guard run codex --dry-run
+hol-guard receipts
+```
+
+## Next guides
+
+- [Local-first runtime and approvals](./local-first-and-approvals.md)
+- [Harness support matrix](./harness-support.md)
+- [Scanner quick start](../plugin-scanner/quick-start.md)

--- a/docs/libraries/ai-plugin-scanner/guard/get-started.md
+++ b/docs/libraries/ai-plugin-scanner/guard/get-started.md
@@ -110,6 +110,8 @@ Supported actions:
 - macOS and Linux: `~/.config/.ai-plugin-scanner-guard/bin/guard-<harness>`
 - Windows: `~/.config/.ai-plugin-scanner-guard/bin/guard-<harness>.cmd`
 
+The hidden `.ai-plugin-scanner-guard` directory name is intentional; Guard uses that home directory under `.config` today.
+
 Claude Code also gets Guard hook entries in `.claude/settings.local.json` when you install from a workspace.
 
 ## Approval paths

--- a/docs/libraries/ai-plugin-scanner/guard/harness-support.md
+++ b/docs/libraries/ai-plugin-scanner/guard/harness-support.md
@@ -1,0 +1,71 @@
+---
+title: Harness support matrix
+sidebar_position: 4
+---
+
+# Harness support matrix
+
+Current Guard support in `ai-plugin-scanner` focuses on reversible overlay behavior and artifact trust before launch.
+
+## Supported harnesses
+
+### Codex
+
+- detects global and project `config.toml`
+- parses configured MCP servers
+- supports wrapper-mode `hol-guard run codex`
+- uses the local approval center for blocked artifact changes today
+
+### Claude Code
+
+- detects global and project settings, hooks, `.mcp.json`, and workspace agents
+- supports local hook install and uninstall in `.claude/settings.local.json`
+- is the strongest current harness for graceful approval deferral
+
+### Cursor
+
+- detects global and project `mcp.json`
+- supports wrapper-mode management state
+- leaves Cursor's native tool approval in place and focuses Guard on artifact trust
+
+### Gemini
+
+- detects local extension manifests and embedded MCP server declarations
+- supports wrapper-mode management state
+- falls back to the local approval center when Guard blocks a launch
+
+### OpenCode
+
+- detects global and project config plus workspace commands
+- supports wrapper-mode management state
+- respects OpenCode permission rules and uses Guard for package-level policy
+
+## Approval tiers
+
+Guard uses these approval tiers:
+
+1. native harness approval when the harness already has strong permission controls
+2. local Guard approval center on `127.0.0.1`
+3. terminal approval resolution through `hol-guard approvals`
+
+## Design principles
+
+Harness adapters are built to prefer:
+
+- discovery before mutation
+- reversible overlays instead of invasive rewrites
+- local evidence and receipts before shared state
+- graceful pause or queue behavior instead of abrupt launch failure
+
+## Suggested first-party canaries
+
+Use these repos to validate Guard against real first-party surfaces:
+
+- `hashnet-mcp-js` for a real MCP server target
+- `registry-broker-skills` for a real skills registry fixture during scan and trust checks
+
+## Next guides
+
+- [Guard get started](./get-started.md)
+- [Local-first runtime and approvals](./local-first-and-approvals.md)
+- [Scanner quick start](../plugin-scanner/quick-start.md)

--- a/docs/libraries/ai-plugin-scanner/guard/local-first-and-approvals.md
+++ b/docs/libraries/ai-plugin-scanner/guard/local-first-and-approvals.md
@@ -1,0 +1,91 @@
+---
+title: Local-first runtime and approvals
+sidebar_position: 3
+---
+
+# Local-first runtime and approvals
+
+HOL Guard is designed so the core safety loop works on one machine first, then grows into shared history and team policy only when that adds real value.
+
+## What works locally before sign-in
+
+Local Guard features available without sign-in:
+
+- harness discovery
+- artifact snapshots
+- local diffs
+- local policy decisions
+- wrapper-mode launch enforcement
+- local receipts and explain output
+- local policy overrides from home or workspace config
+
+Guard does not meter local safety features. You can detect harnesses, install launchers, diff changes, prompt for approval, and inspect receipts without signing in.
+
+## What cloud features add later
+
+Optional cloud features:
+
+- receipt sync to an optional Guard endpoint
+- trust enrichment and advisories
+- revocation feeds
+- billing and entitlements
+- shared team policy
+
+The local runtime does not require a hosted service. `hol-guard login` and `hol-guard sync` layer on shared memory later. They do not unlock the core safety workflow.
+
+## How the runtime is structured
+
+Guard lives inside `ai-plugin-scanner` and uses the existing scan engine as the evidence and trust core.
+
+Runtime layers:
+
+- `guard/adapters` for harness discovery
+- `guard/shims` for launcher overlays
+- `guard/consumer` for detection, policy evaluation, and local output
+- `guard/policy` for action resolution
+- `guard/receipts` for first-use and changed-artifact evidence
+- `guard/runtime` for wrapper-mode launch orchestration and optional sync
+- `guard/store` for SQLite persistence of snapshots, diffs, receipts, installs, and sync state
+
+Guard evaluates local artifacts in this order:
+
+1. discover harness config and managed artifacts
+2. normalize each artifact into a stable snapshot
+3. compare against the last stored snapshot
+4. resolve the effective policy action
+5. record a receipt and optional diff
+6. launch the harness only if the action is not `block`
+
+## What the approval center handles today
+
+The current approval surface is scanner-owned and local:
+
+- `hol-guard run <harness>` evaluates detected artifacts against saved Guard policy before launch
+- interactive terminals can approve or block directly from the inline Guard prompt
+- non-interactive blocked runs queue approval requests in the local Guard daemon instead of failing abruptly
+- the daemon persists pending approvals in SQLite and exposes request detail, receipt detail, diff lookup, and policy upsert endpoints
+- the local approval center serves a browser page on localhost with pending requests, per-request detail, changed fields, receipt evidence, and allow or block forms
+
+## Current fallback-only behavior
+
+These surfaces still rely on the approval center rather than a richer in-client product surface:
+
+- Codex uses the approval center instead of a deeper App Server approval model
+- Gemini routes blocked changes to the approval center rather than a native approval UX
+- terminal approval remains the only native path when Guard is launched from a plain interactive shell
+
+## Practical recommendation
+
+The current everyday loop is:
+
+1. install Guard locally
+2. run through Guard
+3. approve inline when possible
+4. otherwise resolve from the local approval center
+5. review receipts and diffs only when something changes
+
+## Next guides
+
+- [Guard get started](./get-started.md)
+- [Harness support matrix](./harness-support.md)
+- [Policies, output, and trust provenance](../plugin-scanner/policies-and-output.md)

--- a/docs/libraries/ai-plugin-scanner/overview.md
+++ b/docs/libraries/ai-plugin-scanner/overview.md
@@ -36,7 +36,7 @@ hol-guard run codex
 hol-guard approvals
 hol-guard receipts
 hol-guard status
-hol-guard doctor codex --json
+hol-guard detect codex --json
 ```
 
 Supported harnesses today:
@@ -144,11 +144,9 @@ The scanner emits explicit trust provenance alongside quality grades:
 - MCP configuration trust uses HCS-style adapter and contribution-mode patterns
 - top-level plugin trust follows the same pattern locally
 
-Local specs:
+Start with the local trust guide:
 
-- [Skill Trust Local Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/skill-trust-local.md)
-- [MCP Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/mcp-trust-draft.md)
-- [Plugin Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/plugin-trust-draft.md)
+- [Trust provenance guide](./plugin-scanner/trust-provenance.md)
 
 ## Config File
 

--- a/docs/libraries/ai-plugin-scanner/overview.md
+++ b/docs/libraries/ai-plugin-scanner/overview.md
@@ -47,10 +47,11 @@ Supported harnesses today:
 - `gemini`
 - `opencode`
 
-Guard-specific documentation lives in the upstream repo:
+Start with these Guard guides:
 
-- [Guard get started](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/guard/get-started.md)
-- [Guard repository](https://github.com/hashgraph-online/ai-plugin-scanner)
+- [Guard get started](./guard/get-started.md)
+- [Local-first runtime and approvals](./guard/local-first-and-approvals.md)
+- [Harness support matrix](./guard/harness-support.md)
 
 ## plugin-scanner
 
@@ -72,6 +73,7 @@ Current built-in ecosystem adapters:
 ### Scanner quick start
 
 ```bash
+pip install plugin-scanner
 plugin-scanner lint .
 plugin-scanner verify .
 plugin-scanner scan . --format json
@@ -100,6 +102,12 @@ plugin-scanner doctor . --component mcp --bundle dist/doctor.zip
 - trust provenance for skills, MCP configuration, and top-level plugin packages
 
 It supports policy profiles (`default`, `public-marketplace`, `strict-security`), baseline suppressions, config files like `.plugin-scanner.toml`, JSON/Markdown/SARIF output, and repository-mode scanning for marketplace roots that enumerate local plugins under `./plugins/...`.
+
+Start with these scanner guides:
+
+- [Scanner quick start](./plugin-scanner/quick-start.md)
+- [Policies, output, and trust provenance](./plugin-scanner/policies-and-output.md)
+- [GitHub Action quality gate](./plugin-scanner/github-action.md)
 
 ## GitHub Action
 
@@ -178,6 +186,7 @@ docker run --rm \
 - [plugin-scanner on PyPI](https://pypi.org/project/plugin-scanner/)
 - [HOL Plugin Registry](https://hol.org/registry/plugins)
 - [GitHub Repository](https://github.com/hashgraph-online/ai-plugin-scanner)
+- [AI Plugin Scanner Action](https://github.com/hashgraph-online/ai-plugin-scanner-action)
 
 ## Project Basics
 

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/github-action.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/github-action.md
@@ -1,0 +1,83 @@
+---
+title: GitHub Action quality gate
+sidebar_position: 7
+---
+
+# GitHub Action quality gate
+
+Use the Marketplace wrapper when you want `plugin-scanner` in pull requests, release checks, or registry submission workflows.
+
+The action lives in its own repository:
+
+- [hashgraph-online/ai-plugin-scanner-action](https://github.com/hashgraph-online/ai-plugin-scanner-action)
+
+## Minimal quality gate
+
+```yaml
+- name: AI plugin quality gate
+  uses: hashgraph-online/ai-plugin-scanner-action@v1
+  with:
+    plugin_dir: "."
+    mode: scan
+    fail_on_severity: high
+    min_score: 80
+```
+
+## Common modes
+
+- `scan` for weighted quality scoring
+- `lint` for authoring feedback and rule-level findings
+- `verify` for runtime and install-surface checks
+- `submit` for artifact-backed submission gating
+
+## What the action can emit
+
+High-value outputs include:
+
+- `score`
+- `grade`
+- `policy_pass`
+- `verify_pass`
+- `max_severity`
+
+SARIF upload is supported for GitHub code scanning workflows, and the action can also export submission payloads for downstream registry or review automation.
+
+## Typical pull request flow
+
+1. install dependencies for the plugin or marketplace repo
+2. run the action on pull requests with `mode: scan` or `mode: verify`
+3. upload SARIF when you want code scanning annotations
+4. fail the workflow on severity or minimum-score thresholds
+5. switch to `submit` only when the repository is ready to emit release or registry artifacts
+
+## Example with SARIF
+
+```yaml
+- name: Scan plugin
+  id: plugin_scan
+  uses: hashgraph-online/ai-plugin-scanner-action@v1
+  with:
+    plugin_dir: "."
+    mode: scan
+    output_format: sarif
+    sarif_output: plugin-scanner.sarif
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: plugin-scanner.sarif
+```
+
+## Action and CLI together
+
+The common split is:
+
+- `hol-guard` on developer machines for local harness protection
+- `plugin-scanner` in CI for maintainer and release gates
+- `ai-plugin-scanner-action` when you want the scanner wrapped for GitHub Actions consumers
+
+## Next guides
+
+- [Scanner quick start](./quick-start.md)
+- [Policies, output, and trust provenance](./policies-and-output.md)
+- [Guard get started](../guard/get-started.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/policies-and-output.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/policies-and-output.md
@@ -1,0 +1,105 @@
+---
+title: Policies, output, and trust provenance
+sidebar_position: 6
+---
+
+# Policies, output, and trust provenance
+
+`plugin-scanner` separates quality scoring from trust provenance so maintainers can see both readiness and evidence.
+
+## Policy profiles
+
+The scanner ships with policy profiles such as:
+
+- `default`
+- `public-marketplace`
+- `strict-security`
+
+It also supports baseline suppressions and repository-level configuration through `.plugin-scanner.toml`.
+
+Example config:
+
+```toml
+[scanner]
+profile = "public-marketplace"
+baseline_file = "baseline.txt"
+ignore_paths = ["tests/*", "fixtures/*"]
+
+[rules]
+disabled = ["README_MISSING"]
+severity_overrides = { CODEXIGNORE_MISSING = "low" }
+
+[verification]
+online = false
+
+[submission]
+repos = ["hashgraph-online/awesome-codex-plugins"]
+labels = ["plugin-submission"]
+```
+
+## Output formats
+
+Common output modes:
+
+- text for local terminal review
+- JSON for CI and downstream automation
+- Markdown for reviewer-facing summaries
+- SARIF for GitHub code scanning
+
+Examples:
+
+```bash
+plugin-scanner scan . --format text
+plugin-scanner scan . --format json
+plugin-scanner scan . --format markdown
+plugin-scanner scan . --format sarif --output plugin-scanner.sarif
+```
+
+You can also fail CI on severity thresholds:
+
+```bash
+plugin-scanner scan . --fail-on-severity high
+```
+
+## Submission and verification signals
+
+The scanner can emit policy outputs such as:
+
+- `score`
+- `grade`
+- `policy_pass`
+- `verify_pass`
+- `max_severity`
+
+That makes it easy to gate review, registry ingestion, or release workflows on one predictable artifact.
+
+## Trust provenance
+
+The scanner emits explicit trust provenance alongside quality grades:
+
+- bundled skills use published HCS-28 baseline adapter IDs, weights, and denominator rules
+- MCP configuration trust uses HCS-style adapter and contribution-mode patterns
+- top-level plugin trust follows the same pattern locally
+
+Local reference drafts:
+
+- [Skill Trust Local Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/skill-trust-local.md)
+- [MCP Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/mcp-trust-draft.md)
+- [Plugin Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/plugin-trust-draft.md)
+
+## Container usage
+
+Container-first environments can use the published image:
+
+```bash
+docker run --rm \
+  -v "$PWD:/workspace" \
+  ghcr.io/hashgraph-online/ai-plugin-scanner:<version> \
+  scan /workspace --format text
+```
+
+## Next guides
+
+- [Scanner quick start](./quick-start.md)
+- [GitHub Action quality gate](./github-action.md)
+- [Local-first runtime and approvals](../guard/local-first-and-approvals.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/policies-and-output.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/policies-and-output.md
@@ -81,11 +81,9 @@ The scanner emits explicit trust provenance alongside quality grades:
 - MCP configuration trust uses HCS-style adapter and contribution-mode patterns
 - top-level plugin trust follows the same pattern locally
 
-Local reference drafts:
+Start with the local trust guide:
 
-- [Skill Trust Local Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/skill-trust-local.md)
-- [MCP Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/mcp-trust-draft.md)
-- [Plugin Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/plugin-trust-draft.md)
+- [Trust provenance guide](./trust-provenance.md)
 
 ## Container usage
 
@@ -101,5 +99,6 @@ docker run --rm \
 ## Next guides
 
 - [Scanner quick start](./quick-start.md)
+- [Trust provenance guide](./trust-provenance.md)
 - [GitHub Action quality gate](./github-action.md)
 - [Local-first runtime and approvals](../guard/local-first-and-approvals.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/quick-start.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/quick-start.md
@@ -1,0 +1,100 @@
+---
+title: Scanner quick start
+sidebar_position: 5
+---
+
+# Scanner quick start
+
+`plugin-scanner` is the maintainer and CI-facing quality suite inside `hashgraph-online/ai-plugin-scanner`.
+
+Use it after a plugin is scaffolded and before release, registry ingestion, or GitHub review.
+
+## Install
+
+```bash
+pip install plugin-scanner
+```
+
+For isolated shells:
+
+```bash
+pipx install plugin-scanner
+```
+
+Optional Cisco-backed MCP analysis is available on supported Python versions:
+
+```bash
+pip install "plugin-scanner[cisco]"
+```
+
+## First pass
+
+```bash
+plugin-scanner lint .
+plugin-scanner verify .
+plugin-scanner scan . --format json
+```
+
+Add online probing when you want runtime endpoint validation:
+
+```bash
+plugin-scanner verify . --online
+```
+
+Use `doctor` when you want targeted diagnostics and a bundle you can attach to support or CI output:
+
+```bash
+plugin-scanner doctor . --component mcp --bundle dist/doctor.zip
+```
+
+## Supported ecosystems
+
+```bash
+plugin-scanner --list-ecosystems
+```
+
+Current built-in ecosystem adapters:
+
+- Codex
+- Claude Code
+- Gemini CLI
+- OpenCode
+
+Detection surfaces:
+
+| Ecosystem | Detection surfaces |
+| :--- | :--- |
+| Codex | `.codex-plugin/plugin.json`, `marketplace.json`, `.agents/plugins/marketplace.json` |
+| Claude Code | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` |
+| Gemini CLI | `gemini-extension.json`, `commands/**/*.toml` |
+| OpenCode | `opencode.json`, `opencode.jsonc`, `.opencode/commands`, `.opencode/plugins` |
+
+## Core commands
+
+| Command | Purpose |
+| :--- | :--- |
+| `scan` | weighted repository or plugin scan with policy evaluation |
+| `lint` | rule-level findings, `--list-rules`, `--explain`, and safe autofix support |
+| `verify` | runtime and install-surface readiness checks, with optional `--online` probing |
+| `submit` | scan + verify + policy gate that emits a plugin-quality artifact |
+| `doctor` | targeted diagnostics and troubleshooting bundles |
+
+## Repository mode
+
+If your repository uses a Codex marketplace root like `.agents/plugins/marketplace.json`, keep `plugin_dir: "."`. The scanner will discover local `./plugins/...` entries automatically, scan each local plugin manifest, and skip remote marketplace entries instead of treating the repository root as one plugin.
+
+## What it checks
+
+`plugin-scanner` currently covers:
+
+- plugin manifests and marketplace metadata
+- MCP stdio and remote HTTP verification
+- skills, assets, and `.app.json` surfaces
+- security posture such as secrets, dangerous commands, action pinning, and lockfiles
+- trust provenance for skills, MCP configuration, and top-level plugin packages
+
+## Next guides
+
+- [Policies, output, and trust provenance](./policies-and-output.md)
+- [GitHub Action quality gate](./github-action.md)
+- [Guard get started](../guard/get-started.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/trust-provenance.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/trust-provenance.md
@@ -1,0 +1,57 @@
+---
+title: Trust provenance guide
+sidebar_position: 7
+---
+
+# Trust provenance guide
+
+`plugin-scanner` emits explicit trust provenance alongside quality grades so maintainers can see why a package is trusted, not just whether it passed.
+
+## Why provenance is separate from the quality grade
+
+The scanner treats quality and trust as different signals:
+
+- quality summarizes lint, verify, scan, and policy readiness
+- trust provenance summarizes the evidence model behind skills, MCP config, and top-level plugin packages
+
+That split keeps a package from looking "safe" just because its metadata is tidy, and it keeps trust evidence explainable in CI output.
+
+## Bundled skills
+
+Bundled skills use the published HCS-28 baseline adapter catalog directly.
+
+The scanner follows the HCS-28 model for:
+
+- adapter IDs
+- weights
+- contribution modes
+- denominator rules
+
+The local bundled-skill mode keeps the HCS-28 aggregation shape while substituting local evidence for external refresh-only signals where possible.
+
+## MCP configuration trust
+
+MCP configuration trust uses the same HCS-style adapter and contribution-mode pattern locally.
+
+That keeps MCP trust aligned with the broader provenance model instead of inventing a separate scoring language just for local config.
+
+## Top-level plugin trust
+
+Top-level plugin trust follows the same explicit structure:
+
+- named adapters
+- explicit weights
+- deterministic denominator rules
+- conditional adapters only when a surface is actually present
+
+This is why security disclosure, action pinning, manifest integrity, and provenance all remain visible as separate contributors instead of disappearing into one opaque total.
+
+## Local draft sources
+
+The detailed local drafts still live in the upstream `ai-plugin-scanner` repository:
+
+- [Skill Trust Local Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/skill-trust-local.md)
+- [MCP Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/mcp-trust-draft.md)
+- [Plugin Trust Draft](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/trust/plugin-trust-draft.md)
+
+Use those when you need the exact adapter tables or local draft wording. Use this guide when you want the documentation-site explanation of how the scanner surfaces provenance.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -403,6 +403,28 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           items: [
             'libraries/ai-plugin-scanner/overview',
+            {
+              type: 'category',
+              label: 'HOL Guard',
+              collapsible: true,
+              collapsed: true,
+              items: [
+                'libraries/ai-plugin-scanner/guard/get-started',
+                'libraries/ai-plugin-scanner/guard/local-first-and-approvals',
+                'libraries/ai-plugin-scanner/guard/harness-support',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'plugin-scanner',
+              collapsible: true,
+              collapsed: true,
+              items: [
+                'libraries/ai-plugin-scanner/plugin-scanner/quick-start',
+                'libraries/ai-plugin-scanner/plugin-scanner/policies-and-output',
+                'libraries/ai-plugin-scanner/plugin-scanner/github-action',
+              ],
+            },
           ],
         },
       ],

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -422,6 +422,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 'libraries/ai-plugin-scanner/plugin-scanner/quick-start',
                 'libraries/ai-plugin-scanner/plugin-scanner/policies-and-output',
+                'libraries/ai-plugin-scanner/plugin-scanner/trust-provenance',
                 'libraries/ai-plugin-scanner/plugin-scanner/github-action',
               ],
             },


### PR DESCRIPTION
## Summary
- expand the AI Plugin Scanner library section to cover both HOL Guard and plugin-scanner
- add dedicated Guard guides for setup, local-first approvals, and harness support
- add plugin-scanner guides for quick start, policies/output, and GitHub Actions
- wire the new pages into the Docusaurus sidebar

## Verification
- pnpm run build
