### PR TITLE
docs: expand HOL Guard and AI Plugin Scanner guides

### DIFF
--- a/docs/libraries/ai-plugin-scanner/guard/approval-center-and-audit.md
+++ b/docs/libraries/ai-plugin-scanner/guard/approval-center-and-audit.md
@@ -1,0 +1,71 @@
+---
+title: Approval center and audit trail
+sidebar_position: 5
+---
+
+# Approval center and audit trail
+
+This guide explains how Guard routes blocked changes today, what the local approval center exposes, and where the audit trail lives after a harness changes.
+
+## What works now
+
+- `hol-guard run <harness>` evaluates detected artifacts against saved Guard policy before launch
+- interactive terminals can approve or block directly from the inline Guard prompt
+- non-interactive blocked runs queue approval requests in the local Guard daemon instead of failing abruptly
+- the daemon persists pending approvals in SQLite and exposes request detail, receipt detail, diff lookup, and policy upsert endpoints
+- the local approval center serves a browser page on localhost with pending requests, per-request detail, changed fields, receipt evidence, and allow or block forms
+
+## Approval tiers
+
+Guard currently uses three approval tiers:
+
+1. native harness approval when the harness already has a strong permission model
+2. the local Guard approval center on `127.0.0.1`
+3. terminal resolution through `hol-guard approvals`
+
+## Practical state by harness
+
+- `claude-code`
+  - strongest native policy surface today
+  - Guard can work with hooks plus the fallback approval center
+- `codex`
+  - the approval center is the main approval UX today
+  - a richer App Server path remains future-facing
+- `cursor`
+  - Guard focuses on artifact trust before native tool approval
+- `gemini`
+  - blocked changes route to the approval center rather than a richer native approval surface
+- `opencode`
+  - Guard manages artifact trust while OpenCode keeps tool permission semantics
+
+## What the audit trail includes
+
+The current local audit trail centers on:
+
+- pending request list and per-request detail
+- changed fields for the latest artifact comparison
+- receipt list and receipt detail
+- latest stored receipt evidence
+- current policy decisions
+
+## Where the UX is still fallback-only
+
+These surfaces are functional but still feel operational rather than productized:
+
+- the approval center is daemon-served HTML, not a richer web app
+- clients poll HTTP endpoints instead of receiving live daemon updates
+- some harnesses still rely on wrapper-level interruption rather than a native pause or resume model
+
+## Recommended operator loop
+
+1. run through Guard first
+2. approve inline when possible
+3. otherwise resolve from the approval center
+4. inspect receipts and diffs only when something changes
+5. tune policy after repeated approvals show a stable pattern
+
+## Next guides
+
+- [Guard get started](./get-started.md)
+- [Testing and validation](./testing-and-validation.md)
+- [Guard architecture](./architecture.md)

--- a/docs/libraries/ai-plugin-scanner/guard/architecture.md
+++ b/docs/libraries/ai-plugin-scanner/guard/architecture.md
@@ -1,0 +1,59 @@
+---
+title: Guard architecture
+sidebar_position: 6
+---
+
+# Guard architecture
+
+HOL Guard lives inside `hashgraph-online/ai-plugin-scanner` and uses the scanner's evidence pipeline as the trust core. The product loop starts with local harness installs and launch interception rather than CI.
+
+## Runtime layers
+
+The runtime is split into:
+
+- `guard/adapters` for harness discovery across Codex, Claude Code, Cursor, Gemini, and OpenCode
+- `guard/shims` for launcher overlays that route harness launches through Guard
+- `guard/consumer` for detection, policy evaluation, and local output
+- `guard/policy` for action resolution
+- `guard/receipts` for first-use and changed-artifact evidence
+- `guard/runtime` for wrapper-mode launch orchestration and optional sync
+- `guard/store` for SQLite persistence of snapshots, diffs, receipts, installs, and sync state
+
+## Artifact evaluation order
+
+Guard evaluates local artifacts in this order:
+
+1. discover harness config and managed artifacts
+2. normalize each artifact into a stable snapshot
+3. compare against the last stored snapshot
+4. resolve the effective policy action
+5. record a receipt and optional diff
+6. launch the harness only if the action is not `block`
+
+## Product loop
+
+The current local loop is:
+
+1. `hol-guard bootstrap` detects supported harnesses
+2. `hol-guard install <harness>` creates the local launcher shim
+3. `hol-guard run <harness>` evaluates changes before launch
+4. `hol-guard receipts` and `hol-guard status` expose local evidence and current state
+5. `hol-guard login` and `hol-guard sync` stay optional
+
+## What config mutation is limited to
+
+Wrapper mode is still the core execution strategy in this phase. Config mutation is intentionally limited. Claude Code is the notable exception, where Guard can add and remove its own hook entry in workspace-local settings.
+
+## Why this matters for docs
+
+The architectural split explains why the user-facing docs are also split:
+
+- Guard docs focus on harness installs, approvals, receipts, and local policy
+- scanner docs focus on maintainer and CI quality gates
+- GitHub Action docs focus on workflow wiring and outputs
+
+## Next guides
+
+- [Local-first runtime and approvals](./local-first-and-approvals.md)
+- [Approval center and audit trail](./approval-center-and-audit.md)
+- [Harness support matrix](./harness-support.md)

--- a/docs/libraries/ai-plugin-scanner/guard/local-first-vs-cloud.md
+++ b/docs/libraries/ai-plugin-scanner/guard/local-first-vs-cloud.md
@@ -1,0 +1,73 @@
+---
+title: Local-first and optional cloud
+sidebar_position: 4
+---
+
+# Local-first and optional cloud
+
+HOL Guard is designed so the core safety loop works on one machine first. Cloud features layer on later only when shared memory, trust enrichment, or team policy actually helps.
+
+## What works before sign-in
+
+Local Guard features available without sign-in:
+
+- harness discovery
+- artifact snapshots
+- local diffs
+- local policy decisions
+- wrapper-mode launch enforcement
+- local receipts and explain output
+- local policy overrides from home or workspace config
+
+Guard does not meter local safety features. You can detect harnesses, install launchers, diff changes, prompt for approval, and inspect receipts without signing in anywhere.
+
+## What cloud adds later
+
+Optional cloud features include:
+
+- receipt sync to an optional Guard endpoint
+- trust enrichment and curated advisories
+- revocation feeds
+- billing and entitlements
+- shared team policy
+
+`hol-guard login` and `hol-guard sync` extend the local runtime. They do not unlock the core safety workflow.
+
+## Recommended rollout order
+
+For one developer machine:
+
+1. `hol-guard bootstrap`
+2. `hol-guard install <harness>`
+3. `hol-guard run <harness> --dry-run`
+4. `hol-guard run <harness>`
+5. `hol-guard receipts`
+
+For a team:
+
+1. validate the local workflow first
+2. turn on sign-in for receipt sync and advisory feeds
+3. add shared team policy only after the local allow or warn decisions feel stable
+
+## When to stay local only
+
+Local-only Guard is enough when you want:
+
+- per-machine protection for developer harnesses
+- receipts and diffs without any hosted dependency
+- policy overrides that stay tied to one workspace or home config
+
+## When cloud adds clear value
+
+Cloud features start to matter when you need:
+
+- shared history across multiple machines
+- central policy defaults for a team
+- enriched revocation or advisory data
+- billing or entitlement controls for premium Guard surfaces
+
+## Next guides
+
+- [Local-first runtime and approvals](./local-first-and-approvals.md)
+- [Approval center and audit trail](./approval-center-and-audit.md)
+- [Guard get started](./get-started.md)

--- a/docs/libraries/ai-plugin-scanner/guard/testing-and-validation.md
+++ b/docs/libraries/ai-plugin-scanner/guard/testing-and-validation.md
@@ -1,0 +1,63 @@
+---
+title: Testing and validation
+sidebar_position: 8
+---
+
+# Testing and validation
+
+This guide captures the current automated coverage and the manual validation loop maintainers should run before calling a Guard release ready.
+
+## Automated coverage
+
+Current automated coverage includes:
+
+- Guard CLI behavior tests for detect, scan, run, diff, receipts, install, uninstall, login, and sync
+- Guard product-flow tests for `hol-guard start`, `hol-guard status`, and launcher shim creation
+- SQLite persistence through real command execution in temporary homes and workspaces
+- consumer-mode JSON contract generation against scanner fixtures
+- local HTTP sync against a live in-process server instead of mocked transport
+- scheduled self-hosted harness smoke through `.github/workflows/harness-smoke.yml`
+
+## Manual validation loop
+
+Run the following checks before a release or when you change Guard harness behavior:
+
+```bash
+hol-guard start
+hol-guard status
+hol-guard detect codex --json
+hol-guard detect cursor --json
+hol-guard detect gemini --json
+hol-guard detect opencode --json
+hol-guard install codex
+hol-guard run codex --dry-run --default-action allow --json
+hol-guard receipts
+codex mcp list
+cursor-agent mcp list
+gemini --help
+opencode --help
+```
+
+## First-party canaries
+
+Useful local canaries include:
+
+- a local `hashnet-mcp-js` checkout wired into Codex, Cursor, or Claude Code config
+- a local `registry-broker-skills` checkout for scanner fixtures and trust review
+
+Claude Code smoke tests remain conditional on the local `claude` binary being available.
+
+## Release-bar recommendation
+
+Nightly or release-gate coverage should include:
+
+- Codex on a self-hosted Linux runner
+- Claude Code or Cursor on a self-hosted macOS runner
+- Gemini or OpenCode on a self-hosted Windows runner
+- a release gate that only passes when those harness families stay green
+
+## Next guides
+
+- [Harness support matrix](./harness-support.md)
+- [Approval center and audit trail](./approval-center-and-audit.md)
+- [Scanner quick start](../plugin-scanner/quick-start.md)

--- a/docs/libraries/ai-plugin-scanner/overview.md
+++ b/docs/libraries/ai-plugin-scanner/overview.md
@@ -51,7 +51,11 @@ Start with these Guard guides:
 
 - [Guard get started](./guard/get-started.md)
 - [Local-first runtime and approvals](./guard/local-first-and-approvals.md)
+- [Local-first and optional cloud](./guard/local-first-vs-cloud.md)
+- [Approval center and audit trail](./guard/approval-center-and-audit.md)
+- [Guard architecture](./guard/architecture.md)
 - [Harness support matrix](./guard/harness-support.md)
+- [Testing and validation](./guard/testing-and-validation.md)
 
 ## plugin-scanner
 
@@ -106,35 +110,20 @@ It supports policy profiles (`default`, `public-marketplace`, `strict-security`)
 Start with these scanner guides:
 
 - [Scanner quick start](./plugin-scanner/quick-start.md)
+- [Ecosystems and repository mode](./plugin-scanner/ecosystems-and-repo-mode.md)
+- [Quality suite commands](./plugin-scanner/quality-suite-commands.md)
 - [Policies, output, and trust provenance](./plugin-scanner/policies-and-output.md)
-- [GitHub Action quality gate](./plugin-scanner/github-action.md)
+- [Trust provenance guide](./plugin-scanner/trust-provenance.md)
+- [Report formats and CI automation](./plugin-scanner/report-formats-and-ci.md)
 
 ## GitHub Action
 
-Use the Marketplace wrapper when you want the scanner in GitHub Actions:
+The Marketplace wrapper lives in the dedicated [`hashgraph-online/ai-plugin-scanner-action`](https://github.com/hashgraph-online/ai-plugin-scanner-action) repository. Use it when you want scanner checks in pull requests, release workflows, submission intake, or code-scanning automation without installing the CLI yourself.
 
-```yaml
-- name: AI plugin quality gate
-  uses: hashgraph-online/ai-plugin-scanner-action@v1
-  with:
-    plugin_dir: "."
-    mode: scan
-    fail_on_severity: high
-    min_score: 80
-```
+Start with these action guides:
 
-High-value action capabilities:
-
-- `mode: scan | lint | verify | submit`
-- SARIF upload to GitHub code scanning
-- policy outputs like `score`, `grade`, `policy_pass`, `verify_pass`, and `max_severity`
-- optional submission flows and registry payload export
-- default package installation from the reviewed `plugin-scanner` PyPI release
-
-For the full action contract, use the upstream action documentation:
-
-- [AI Plugin Scanner Action README](https://github.com/hashgraph-online/ai-plugin-scanner-action/blob/main/README.md)
-- [Marketplace action repository](https://github.com/hashgraph-online/ai-plugin-scanner-action)
+- [GitHub Action quality gate](./plugin-scanner/github-action.md)
+- [Submission and registry payloads](./plugin-scanner/submission-and-registry-payloads.md)
 
 ## Trust Score Provenance
 

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/ecosystems-and-repo-mode.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/ecosystems-and-repo-mode.md
@@ -1,0 +1,58 @@
+---
+title: Ecosystems and repository mode
+sidebar_position: 6
+---
+
+# Ecosystems and repository mode
+
+`plugin-scanner` can work against one plugin package or auto-detect multiple supported ecosystems inside a repository root.
+
+## Supported ecosystems
+
+| Ecosystem | Detection surfaces |
+| :--- | :--- |
+| Codex | `.codex-plugin/plugin.json`, `marketplace.json`, `.agents/plugins/marketplace.json` |
+| Claude Code | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` |
+| Gemini CLI | `gemini-extension.json`, `commands/**/*.toml` |
+| OpenCode | `opencode.json`, `opencode.jsonc`, `.opencode/commands`, `.opencode/plugins` |
+
+Use `--ecosystem auto` to scan all detected packages in a repository, or select a single ecosystem explicitly when you only want one family.
+
+## Repository mode
+
+Repository mode matters most for marketplace roots:
+
+```bash
+plugin-scanner scan . --format json
+plugin-scanner lint . --format json
+plugin-scanner verify . --format json
+plugin-scanner doctor . --component mcp --bundle dist/doctor.zip
+```
+
+If your repository uses a Codex marketplace root like `.agents/plugins/marketplace.json`, keep `plugin_dir: "."`. The scanner will discover local `./plugins/...` entries automatically, scan each local plugin manifest, and skip remote marketplace entries instead of treating the repository root as one plugin.
+
+## Codex packaging alignment
+
+The scanner follows the current Codex packaging conventions more closely:
+
+- local manifest paths should use `./` prefixes
+- `.agents/plugins/marketplace.json` is the preferred marketplace manifest location
+- root `marketplace.json` is still supported in compatibility mode
+- `interface` metadata no longer requires an undocumented `type` field
+- `verify` performs an MCP initialize handshake before probing declared capabilities
+
+`submit` remains intentionally single-plugin so the emitted artifact always points at one concrete plugin package.
+
+## Useful discovery commands
+
+```bash
+plugin-scanner --list-ecosystems
+plugin-scanner . --ecosystem auto
+plugin-scanner . --ecosystem claude
+```
+
+## Next guides
+
+- [Scanner quick start](./quick-start.md)
+- [Quality suite commands](./quality-suite-commands.md)
+- [GitHub Action quality gate](./github-action.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/github-action.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/github-action.md
@@ -78,6 +78,7 @@ The common split is:
 
 ## Next guides
 
+- [Submission and registry payloads](./submission-and-registry-payloads.md)
+- [Report formats and CI automation](./report-formats-and-ci.md)
 - [Scanner quick start](./quick-start.md)
-- [Policies, output, and trust provenance](./policies-and-output.md)
 - [Guard get started](../guard/get-started.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/policies-and-output.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/policies-and-output.md
@@ -99,6 +99,8 @@ docker run --rm \
 ## Next guides
 
 - [Scanner quick start](./quick-start.md)
+- [Quality suite commands](./quality-suite-commands.md)
+- [Report formats and CI automation](./report-formats-and-ci.md)
 - [Trust provenance guide](./trust-provenance.md)
 - [GitHub Action quality gate](./github-action.md)
 - [Local-first runtime and approvals](../guard/local-first-and-approvals.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/quality-suite-commands.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/quality-suite-commands.md
@@ -1,0 +1,73 @@
+---
+title: Quality suite commands
+sidebar_position: 7
+---
+
+# Quality suite commands
+
+`plugin-scanner` ships five main maintainer and CI commands. Each one answers a different release question.
+
+## `scan`
+
+Use `scan` when you want the weighted summary view:
+
+```bash
+plugin-scanner scan ./my-plugin --format json --profile public-marketplace
+plugin-scanner scan . --format json
+```
+
+`scan` evaluates only the surfaces a plugin actually exposes, then normalizes the final score across applicable checks.
+
+## `lint`
+
+Use `lint` when you want rule-oriented authoring feedback:
+
+```bash
+plugin-scanner lint ./my-plugin --list-rules
+plugin-scanner lint ./my-plugin --explain README_MISSING
+plugin-scanner lint ./my-plugin --fix --profile strict-security
+```
+
+## `verify`
+
+Use `verify` when you want runtime or install-surface readiness checks:
+
+```bash
+plugin-scanner verify ./my-plugin --format json
+plugin-scanner verify . --format json
+plugin-scanner verify ./my-plugin --online --format text
+```
+
+## `submit`
+
+Use `submit` when you want one artifact-backed gate before release or ecosystem intake:
+
+```bash
+plugin-scanner submit ./my-plugin --profile public-marketplace --attest dist/plugin-quality.json
+```
+
+`submit` stays single-plugin on purpose so the emitted quality artifact points at one concrete package.
+
+## `doctor`
+
+Use `doctor` when you want targeted diagnostics or a troubleshooting bundle:
+
+```bash
+plugin-scanner doctor ./my-plugin --component mcp --bundle dist/doctor.zip
+```
+
+## When to use which command
+
+| Command | Best use |
+| :--- | :--- |
+| `scan` | weighted release summary and policy evaluation |
+| `lint` | authoring feedback and safe mechanical fixes |
+| `verify` | runtime readiness and install-surface checks |
+| `submit` | artifact-backed release or submission gate |
+| `doctor` | targeted diagnostics and support bundles |
+
+## Next guides
+
+- [Ecosystems and repository mode](./ecosystems-and-repo-mode.md)
+- [Policies, output, and trust provenance](./policies-and-output.md)
+- [Submission and registry payloads](./submission-and-registry-payloads.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/quick-start.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/quick-start.md
@@ -95,6 +95,8 @@ If your repository uses a Codex marketplace root like `.agents/plugins/marketpla
 
 ## Next guides
 
+- [Ecosystems and repository mode](./ecosystems-and-repo-mode.md)
+- [Quality suite commands](./quality-suite-commands.md)
 - [Policies, output, and trust provenance](./policies-and-output.md)
 - [GitHub Action quality gate](./github-action.md)
 - [Guard get started](../guard/get-started.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/report-formats-and-ci.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/report-formats-and-ci.md
@@ -1,0 +1,100 @@
+---
+title: Report formats and CI automation
+sidebar_position: 9
+---
+
+# Report formats and CI automation
+
+`plugin-scanner` can emit human-readable summaries, machine-readable artifacts, and GitHub-friendly security reports from the same scan.
+
+## Report formats
+
+| Format | Best use |
+| :--- | :--- |
+| `text` | local terminal review with category totals and findings |
+| `json` | structured integrations and dashboards |
+| `markdown` | pull request or issue-ready summaries |
+| `sarif` | GitHub code scanning uploads and security automation |
+
+Examples:
+
+```bash
+plugin-scanner scan . --format text
+plugin-scanner scan . --format json
+plugin-scanner scan . --format markdown
+plugin-scanner scan . --format sarif --output plugin-scanner.sarif
+```
+
+## Common gating flags
+
+Fail CI when a finding crosses your severity floor:
+
+```bash
+plugin-scanner scan . --fail-on-severity high
+```
+
+Require stronger optional integrations when needed:
+
+```bash
+plugin-scanner ./my-plugin --cisco-skill-scan on --cisco-policy strict
+plugin-scanner ./my-plugin --cisco-mcp-scan on
+```
+
+## Signals emitted by the suite
+
+The scanner can emit stable machine signals such as:
+
+- `score`
+- `grade`
+- `grade_label`
+- `policy_pass`
+- `verify_pass`
+- `max_severity`
+- `findings_total`
+
+That makes it easy to gate review, registry ingestion, or release workflows on one predictable artifact.
+
+## CLI-first CI pattern
+
+Use the CLI directly when you want the repository to control install, caching, and report upload:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install scanner
+        run: pip install plugin-scanner
+      - name: Scan plugin
+        run: plugin-scanner scan . --format sarif --output plugin-scanner.sarif --fail-on-severity high
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: plugin-scanner.sarif
+```
+
+## Local pre-commit pattern
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: plugin-scanner
+        name: Plugin Scanner
+        entry: plugin-scanner
+        language: system
+        types: [directory]
+        pass_filenames: false
+        args: ["./"]
+```
+
+## Next guides
+
+- [Policies, output, and trust provenance](./policies-and-output.md)
+- [GitHub Action quality gate](./github-action.md)
+- [Submission and registry payloads](./submission-and-registry-payloads.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/report-formats-and-ci.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/report-formats-and-ci.md
@@ -67,7 +67,7 @@ jobs:
   scan-plugin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Install scanner
         run: pip install plugin-scanner
       - name: Scan plugin

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/submission-and-registry-payloads.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/submission-and-registry-payloads.md
@@ -1,0 +1,94 @@
+---
+title: Submission and registry payloads
+sidebar_position: 11
+---
+
+# Submission and registry payloads
+
+The GitHub Action can do more than fail a pull request. It can also open or reuse ecosystem submission issues and emit a registry payload file for downstream automation.
+
+## Submission flow
+
+The intended path is:
+
+1. add the scanner action to plugin CI
+2. require `min_score: 80` and a severity gate such as `fail_on_severity: high`
+3. enable submission mode with a token that has `issues:write` on `hashgraph-online/awesome-codex-plugins`
+4. when the plugin clears the threshold, the action opens or reuses a submission issue
+5. the issue body includes machine-readable registry payload data so the same event can drive ecosystem automation
+
+Example:
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  scan-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan and submit if eligible
+        id: scan
+        uses: hashgraph-online/ai-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high
+          submission_enabled: true
+          submission_score_threshold: 80
+          submission_token: ${{ secrets.AWESOME_CODEX_PLUGINS_TOKEN }}
+```
+
+`submission_token` is required when `submission_enabled: true`. The flow is idempotent: if the plugin repository was already submitted, the action reuses the existing open issue instead of opening duplicates.
+
+## Action outputs
+
+High-value outputs include:
+
+- `score`
+- `grade`
+- `grade_label`
+- `max_severity`
+- `findings_total`
+- `submission_performed`
+- `submission_issue_urls`
+
+## Registry payload export
+
+If you want to feed the same scan into a registry, badge pipeline, or another plugin ecosystem automation step, request a registry payload file directly from the action:
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  scan-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan plugin
+        id: scan
+        uses: hashgraph-online/ai-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          format: sarif
+          output: ai-plugin-scanner.sarif
+          registry_payload_output: ai-plugin-registry-payload.json
+
+      - name: Upload registry payload
+        uses: actions/upload-artifact@v6
+        with:
+          name: ai-plugin-registry-payload
+          path: ${{ steps.scan.outputs.registry_payload_path }}
+```
+
+The registry payload mirrors the submission data used by HOL ecosystem automation, so one scan can drive code scanning, review summaries, awesome-list intake, and registry trust ingestion.
+
+## Next guides
+
+- [GitHub Action quality gate](./github-action.md)
+- [Report formats and CI automation](./report-formats-and-ci.md)
+- [Policies, output, and trust provenance](./policies-and-output.md)

--- a/docs/libraries/ai-plugin-scanner/plugin-scanner/submission-and-registry-payloads.md
+++ b/docs/libraries/ai-plugin-scanner/plugin-scanner/submission-and-registry-payloads.md
@@ -27,7 +27,7 @@ jobs:
   scan-plugin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Scan and submit if eligible
         id: scan
@@ -67,7 +67,7 @@ jobs:
   scan-plugin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Scan plugin
         id: scan
@@ -79,7 +79,7 @@ jobs:
           registry_payload_output: ai-plugin-registry-payload.json
 
       - name: Upload registry payload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ai-plugin-registry-payload
           path: ${{ steps.scan.outputs.registry_payload_path }}

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -411,7 +411,11 @@ const sidebars: SidebarsConfig = {
               items: [
                 'libraries/ai-plugin-scanner/guard/get-started',
                 'libraries/ai-plugin-scanner/guard/local-first-and-approvals',
+                'libraries/ai-plugin-scanner/guard/local-first-vs-cloud',
+                'libraries/ai-plugin-scanner/guard/approval-center-and-audit',
+                'libraries/ai-plugin-scanner/guard/architecture',
                 'libraries/ai-plugin-scanner/guard/harness-support',
+                'libraries/ai-plugin-scanner/guard/testing-and-validation',
               ],
             },
             {
@@ -421,9 +425,21 @@ const sidebars: SidebarsConfig = {
               collapsed: true,
               items: [
                 'libraries/ai-plugin-scanner/plugin-scanner/quick-start',
+                'libraries/ai-plugin-scanner/plugin-scanner/ecosystems-and-repo-mode',
+                'libraries/ai-plugin-scanner/plugin-scanner/quality-suite-commands',
                 'libraries/ai-plugin-scanner/plugin-scanner/policies-and-output',
                 'libraries/ai-plugin-scanner/plugin-scanner/trust-provenance',
+                'libraries/ai-plugin-scanner/plugin-scanner/report-formats-and-ci',
+              ],
+            },
+            {
+              type: 'category',
+              label: 'GitHub Action',
+              collapsible: true,
+              collapsed: true,
+              items: [
                 'libraries/ai-plugin-scanner/plugin-scanner/github-action',
+                'libraries/ai-plugin-scanner/plugin-scanner/submission-and-registry-payloads',
               ],
             },
           ],


### PR DESCRIPTION
## Summary
- add deeper HOL Guard docs for architecture, local-vs-cloud, approval audit flow, and validation
- expand plugin-scanner docs for ecosystems, repo mode, quality-suite commands, CI formats, and submission payloads
- split GitHub Action guidance into its own section after HOL Guard and plugin-scanner

## Verification
- pnpm run build
- pnpm run typecheck *(existing unrelated repo baseline failures in theme/components outside this docs section)*