### PR TITLE
docs: add Guard Cloud workflow guides

### DIFF
--- a/docs/libraries/ai-plugin-scanner/guard/alerts-watchlists-and-advisories.md
+++ b/docs/libraries/ai-plugin-scanner/guard/alerts-watchlists-and-advisories.md
@@ -1,0 +1,62 @@
+---
+title: Alerts, watchlists, and advisories
+---
+
+# Alerts, watchlists, and advisories
+
+Use this guide when you want Guard Cloud to interrupt you only when the risk is worth it.
+
+## What Alerts is for
+
+`/guard/alerts` is where Guard stops being a passive log and becomes an operator surface.
+
+The route is built around three jobs:
+
+- choose a digest posture that keeps the dashboard calm
+- define watchlist items that should always break through
+- connect shared artifact history to advisory or revocation-aware follow-up
+
+## Watchlists versus general noise
+
+Not every change deserves the same interruption level.
+
+Use a watchlist when:
+
+- one dependency or publisher is especially sensitive
+- a risky artifact should always notify the team
+- you want Guard to stay quiet everywhere else
+
+Use digest mode when:
+
+- the team mainly needs a daily or periodic review loop
+- changed approvals are better handled from the command center than from chatty notifications
+
+## Where advisories and revocations fit
+
+Guard Cloud can layer curated trust data on top of synced receipts.
+
+That matters when:
+
+- something you trusted becomes risky later
+- a previously accepted artifact should be reconsidered
+- alerting needs more than “a file changed”
+
+## Healthy alert posture
+
+A healthy setup usually looks like:
+
+1. quiet by default
+2. one clear digest mode
+3. small watchlists for truly high-risk items
+4. policy doing most of the repetitive work before alerts fire
+
+## See it in product
+
+- [Guard alerts](https://hol.org/guard/alerts)
+- [Guard dashboard](https://hol.org/guard/dashboard)
+
+## Next guides
+
+- [Receipts, changes, and history](./receipts-changes-and-history.md)
+- [Team policy and delegated approvals](./team-policy-and-delegated-approvals.md)
+- [Billing, credits, and plans](./billing-credits-and-plans.md)

--- a/docs/libraries/ai-plugin-scanner/guard/approval-center-and-audit.md
+++ b/docs/libraries/ai-plugin-scanner/guard/approval-center-and-audit.md
@@ -66,6 +66,6 @@ These surfaces are functional but still feel operational rather than productized
 
 ## Next guides
 
-- [Guard get started](./get-started.md)
-- [Testing and validation](./testing-and-validation.md)
-- [Guard architecture](./architecture.md)
+- [Receipts, changes, and history](./receipts-changes-and-history.md)
+- [Inventory, ABOM, and artifact detail](./inventory-abom-and-artifact-detail.md)
+- [Exceptions and expiring windows](./exceptions-and-expiring-windows.md)

--- a/docs/libraries/ai-plugin-scanner/guard/billing-credits-and-plans.md
+++ b/docs/libraries/ai-plugin-scanner/guard/billing-credits-and-plans.md
@@ -4,7 +4,7 @@ title: Billing, credits, and plans
 
 # Billing, credits, and plans
 
-Use this guide when you need to explain what stays free in local Guard, what Guard Cloud adds later, and why plan pressure should feel like pain relief instead of random upsell.
+Use this guide when you want to understand what stays free in local Guard, what Guard Cloud adds later, and why plan pressure should feel like pain relief instead of random upsell.
 
 ## What stays local and unmetered
 

--- a/docs/libraries/ai-plugin-scanner/guard/billing-credits-and-plans.md
+++ b/docs/libraries/ai-plugin-scanner/guard/billing-credits-and-plans.md
@@ -1,0 +1,60 @@
+---
+title: Billing, credits, and plans
+---
+
+# Billing, credits, and plans
+
+Use this guide when you need to explain what stays free in local Guard, what Guard Cloud adds later, and why plan pressure should feel like pain relief instead of random upsell.
+
+## What stays local and unmetered
+
+Core local Guard safety is not the premium story.
+
+Local Guard still gives you:
+
+- harness discovery
+- install and wrapper protection
+- local approvals
+- local receipts and diffs
+- local policy decisions
+
+That is why Guard can feel useful before sign-in.
+
+## What billing is actually attached to
+
+`/guard/billing` and related plan routes matter when the cloud product is doing work such as:
+
+- syncing trust memory across devices
+- keeping longer receipt history
+- powering alerts and watchlists
+- sharing policy across a team
+- supporting delegated approvals and managed workspaces
+
+## Read billing as operator pressure
+
+The Billing route is most useful when it answers:
+
+- are device or sync limits blocking the command center from becoming useful?
+- are credits or buckets shaping what Guard can remember?
+- is the current plan still aligned with how many people or machines rely on shared trust memory?
+
+## Good upgrade moments
+
+The strongest upgrade moments are operational, not cosmetic:
+
+- “I do not want to rebuild trust memory on another laptop.”
+- “I need alerts when a trusted artifact changes.”
+- “My team should not rediscover the same policy every week.”
+- “Managed workspaces need one approval queue.”
+
+## See it in product
+
+- [Guard billing](https://hol.org/guard/billing)
+- [Guard plan](https://hol.org/guard/plan)
+- [Guard pricing](https://hol.org/guard/pricing)
+
+## Next guides
+
+- [Guard Cloud command center](./guard-cloud-command-center.md)
+- [Devices and shared trust memory](./devices-and-shared-trust.md)
+- [Local-first and optional cloud](./local-first-vs-cloud.md)

--- a/docs/libraries/ai-plugin-scanner/guard/devices-and-shared-trust.md
+++ b/docs/libraries/ai-plugin-scanner/guard/devices-and-shared-trust.md
@@ -1,0 +1,56 @@
+---
+title: Devices and shared trust memory
+---
+
+# Devices and shared trust memory
+
+Use this guide when you want to understand what `/guard/devices` tells you after Guard starts protecting more than one harness or machine.
+
+## What the route tracks
+
+The Devices route is the quickest answer to:
+
+- which devices Guard has seen recently
+- which harnesses are actually protected on each device
+- which machines are only local and which are syncing
+- whether trust memory is spreading cleanly across the estate
+
+This route matters because Guard is much easier to trust when you can see that protection is consistent instead of silently drifting by laptop.
+
+## Why shared trust memory matters
+
+Local Guard is enough for one machine. Shared trust memory starts to matter when:
+
+- you switch between workstations
+- you want the same artifact decision to survive a new laptop
+- a team needs one cross-device history instead of one-person receipts
+- alerts should reflect the estate, not only one terminal session
+
+## Healthy state
+
+A healthy Devices view looks like:
+
+1. expected machines show up
+2. each machine reports the harnesses you meant to protect
+3. last-seen timestamps stay fresh
+4. synced devices are not rebuilding the same trust decisions over and over
+
+## When the route is telling you something is off
+
+Treat Devices as an operator signal when:
+
+- a harness is missing from a machine that should be protected
+- last-seen timestamps go stale
+- new devices never start syncing receipts
+- the dashboard keeps feeling empty because no shared memory is landing
+
+## See it in product
+
+- [Guard devices](https://hol.org/guard/devices)
+- [Guard install](https://hol.org/guard/install)
+
+## Next guides
+
+- [Guard Cloud command center](./guard-cloud-command-center.md)
+- [Inventory, ABOM, and artifact detail](./inventory-abom-and-artifact-detail.md)
+- [Billing, credits, and plans](./billing-credits-and-plans.md)

--- a/docs/libraries/ai-plugin-scanner/guard/exceptions-and-expiring-windows.md
+++ b/docs/libraries/ai-plugin-scanner/guard/exceptions-and-expiring-windows.md
@@ -1,0 +1,54 @@
+---
+title: Exceptions and expiring windows
+---
+
+# Exceptions and expiring windows
+
+Use this guide when a team needs a temporary Guard bypass without silently turning that bypass into the new normal.
+
+## What the route is for
+
+`/guard/exceptions` keeps three things together:
+
+- pending exception requests
+- active exception windows
+- which windows are about to expire
+
+That matters because friction reduction only stays safe when the team can still answer who asked, why it exists, and when it ends.
+
+## What belongs in an exception
+
+Exceptions are best for:
+
+- short-lived unblock moments
+- time-bound approvals that should not become policy
+- cases where the operator already knows this is the unusual path
+
+Exceptions are a poor substitute for:
+
+- missing shared policy defaults
+- stable allow decisions that should move into policy
+- long-lived process debt no one wants to revisit
+
+## Recommended operator loop
+
+1. review pending requests
+2. approve or reject with a clear rationale
+3. watch active windows for expiry
+4. remove old windows instead of letting them linger
+5. promote repeated exceptions into policy if the same request keeps returning
+
+## Relationship to team policy
+
+Exceptions work best when a team policy pack already exists. Otherwise the queue becomes person-to-person friction instead of a controlled operating system.
+
+## See it in product
+
+- [Guard exceptions](https://hol.org/guard/exceptions)
+- [Guard policy](https://hol.org/guard/policy)
+
+## Next guides
+
+- [Team policy and delegated approvals](./team-policy-and-delegated-approvals.md)
+- [Receipts, changes, and history](./receipts-changes-and-history.md)
+- [Approval center and audit trail](./approval-center-and-audit.md)

--- a/docs/libraries/ai-plugin-scanner/guard/guard-cloud-command-center.md
+++ b/docs/libraries/ai-plugin-scanner/guard/guard-cloud-command-center.md
@@ -1,0 +1,75 @@
+---
+title: Guard Cloud command center
+---
+
+# Guard Cloud command center
+
+Use this guide when local Guard is already protecting a harness and you want the signed-in product to feel like one operating system instead of a set of unrelated routes.
+
+## What this part of Guard is for
+
+Guard Cloud takes the local runtime evidence you already trust and turns it into shared memory:
+
+- synced receipts across devices
+- changed-after-approval review queues
+- watchlists, advisories, and revocation-aware alerts
+- shared policy defaults for teams
+- delegated approvals for managed workspaces
+- billing and plan pressure that explains what cloud value is actually unlocked
+
+## Command center routes
+
+| Route | What it answers |
+| :--- | :--- |
+| `/guard/dashboard` | What needs attention right now, what Guard already handled, and what to do next |
+| `/guard/devices` | Which devices and harnesses are protected, connected, and syncing |
+| `/guard/changes` | Which approved artifacts drifted and now need review |
+| `/guard/alerts` | Which risky changes should interrupt you and which can stay in digest form |
+| `/guard/artifacts` | What lives in shared inventory and how artifact trust looks right now |
+| `/guard/receipts` | What the latest synced receipts say before you open long-term history |
+| `/guard/policy` | Which shared defaults should apply across the team |
+| `/guard/exceptions` | Which temporary bypass windows are still active or expiring |
+| `/guard/agents` | How delegated approvals and managed workspaces flow through Guard |
+| `/guard/billing` | Which plan, credits, and cloud limits are shaping the operator experience |
+
+## Dashboard modes and next actions
+
+The signed-in dashboard is easier to understand if you treat it as a state-aware command center:
+
+1. **Onboarding** — signed in, but no protected runtime has shown up yet
+2. **Solo local-only** — Guard is protecting one machine, but trust history still stops there
+3. **Solo synced** — receipts are syncing, so Home can highlight changed artifacts instead of setup chores
+4. **Team admin** — the shared queue matters more than one laptop, so policy and exceptions move to the center
+5. **Workspace operator** — delegated approvals and managed agents become the primary operating surface
+
+Each mode should answer the same questions:
+
+- what changed?
+- what needs a decision?
+- what has Guard already handled?
+- what should I do next?
+- which route should I open next?
+
+## How local Guard hands off to cloud Guard
+
+The cleanest rollout is:
+
+1. protect one harness locally
+2. record real receipts and diffs
+3. turn on sign-in and sync
+4. let the dashboard summarize what changed instead of replaying local setup
+5. add shared policy only when repeated approvals show a stable operating pattern
+
+That handoff matters because Guard Cloud should explain the local runtime, not replace it.
+
+## See it in product
+
+- [Guard dashboard](https://hol.org/guard/dashboard)
+- [Guard devices](https://hol.org/guard/devices)
+- [Guard policy](https://hol.org/guard/policy)
+
+## Next guides
+
+- [Devices and shared trust memory](./devices-and-shared-trust.md)
+- [Receipts, changes, and history](./receipts-changes-and-history.md)
+- [Team policy and delegated approvals](./team-policy-and-delegated-approvals.md)

--- a/docs/libraries/ai-plugin-scanner/guard/guard-cloud-command-center.md
+++ b/docs/libraries/ai-plugin-scanner/guard/guard-cloud-command-center.md
@@ -24,8 +24,10 @@ Guard Cloud takes the local runtime evidence you already trust and turns it into
 | `/guard/dashboard` | What needs attention right now, what Guard already handled, and what to do next |
 | `/guard/devices` | Which devices and harnesses are protected, connected, and syncing |
 | `/guard/changes` | Which approved artifacts drifted and now need review |
+| `/guard/history` | Long-term timeline and drift patterns for artifacts |
 | `/guard/alerts` | Which risky changes should interrupt you and which can stay in digest form |
 | `/guard/artifacts` | What lives in shared inventory and how artifact trust looks right now |
+| `/guard/abom` | The artifact bill of materials view for the broader trust estate |
 | `/guard/receipts` | What the latest synced receipts say before you open long-term history |
 | `/guard/policy` | Which shared defaults should apply across the team |
 | `/guard/exceptions` | Which temporary bypass windows are still active or expiring |
@@ -38,7 +40,7 @@ The signed-in dashboard is easier to understand if you treat it as a state-aware
 
 1. **Onboarding** — signed in, but no protected runtime has shown up yet
 2. **Solo local-only** — Guard is protecting one machine, but trust history still stops there
-3. **Solo synced** — receipts are syncing, so Home can highlight changed artifacts instead of setup chores
+3. **Solo synced** — receipts are syncing, so the dashboard can highlight changed artifacts instead of setup chores
 4. **Team admin** — the shared queue matters more than one laptop, so policy and exceptions move to the center
 5. **Workspace operator** — delegated approvals and managed agents become the primary operating surface
 

--- a/docs/libraries/ai-plugin-scanner/guard/inventory-abom-and-artifact-detail.md
+++ b/docs/libraries/ai-plugin-scanner/guard/inventory-abom-and-artifact-detail.md
@@ -1,0 +1,65 @@
+---
+title: Inventory, ABOM, and artifact detail
+---
+
+# Inventory, ABOM, and artifact detail
+
+Use this guide when you want to understand the difference between `/guard/artifacts`, `/guard/inventory`, `/guard/abom`, and an individual artifact detail page.
+
+## The three layers
+
+Guard Cloud keeps these views separate on purpose:
+
+1. **Inventory** — the current shared list of tracked artifacts and their latest known state
+2. **ABOM** — the artifact bill of materials view for the broader trust estate
+3. **Artifact detail** — one artifact timeline, evidence set, and current decision surface
+
+Keeping those layers separate makes it easier to answer whether something is merely present, recently changed, or worth deeper inspection.
+
+## Which route to open first
+
+| Route | Best first question |
+| :--- | :--- |
+| `/guard/artifacts` or `/guard/inventory` | What is in shared trust memory right now? |
+| `/guard/abom` | What does the broader artifact estate look like at a system level? |
+| `/guard/artifacts/<id>` | What happened to this one artifact over time? |
+
+## What belongs in inventory
+
+Inventory is the everyday operator view:
+
+- latest decision
+- latest changed state
+- known devices and harnesses
+- whether something drifted after approval
+
+Open inventory first when the dashboard says something changed and you want the shortest route to context.
+
+## What ABOM is for
+
+ABOM is the estate-level answer. It is useful when you want:
+
+- a wider map of the trust surface
+- artifact-level visibility that is less queue-shaped than Changes
+- a clearer summary of what Guard is tracking across the organization
+
+## When to open artifact detail
+
+Artifact detail is where you slow down:
+
+- inspect the latest evidence
+- compare current and prior receipt state
+- understand why Guard now wants another decision
+- see the timeline without flattening it into a queue badge
+
+## See it in product
+
+- [Guard inventory](https://hol.org/guard/inventory)
+- [Guard artifacts](https://hol.org/guard/artifacts)
+- [Guard ABOM](https://hol.org/guard/abom)
+
+## Next guides
+
+- [Receipts, changes, and history](./receipts-changes-and-history.md)
+- [Alerts, watchlists, and advisories](./alerts-watchlists-and-advisories.md)
+- [Approval center and audit trail](./approval-center-and-audit.md)

--- a/docs/libraries/ai-plugin-scanner/guard/inventory-abom-and-artifact-detail.md
+++ b/docs/libraries/ai-plugin-scanner/guard/inventory-abom-and-artifact-detail.md
@@ -22,7 +22,7 @@ Keeping those layers separate makes it easier to answer whether something is mer
 | :--- | :--- |
 | `/guard/artifacts` or `/guard/inventory` | What is in shared trust memory right now? |
 | `/guard/abom` | What does the broader artifact estate look like at a system level? |
-| `/guard/artifacts/<id>` | What happened to this one artifact over time? |
+| `/guard/artifacts/:id` | What happened to this one artifact over time? |
 
 ## What belongs in inventory
 

--- a/docs/libraries/ai-plugin-scanner/guard/local-first-vs-cloud.md
+++ b/docs/libraries/ai-plugin-scanner/guard/local-first-vs-cloud.md
@@ -68,6 +68,6 @@ Cloud features start to matter when you need:
 
 ## Next guides
 
-- [Local-first runtime and approvals](./local-first-and-approvals.md)
-- [Approval center and audit trail](./approval-center-and-audit.md)
-- [Guard get started](./get-started.md)
+- [Guard Cloud command center](./guard-cloud-command-center.md)
+- [Devices and shared trust memory](./devices-and-shared-trust.md)
+- [Billing, credits, and plans](./billing-credits-and-plans.md)

--- a/docs/libraries/ai-plugin-scanner/guard/receipts-changes-and-history.md
+++ b/docs/libraries/ai-plugin-scanner/guard/receipts-changes-and-history.md
@@ -1,0 +1,60 @@
+---
+title: Receipts, changes, and history
+---
+
+# Receipts, changes, and history
+
+Use this guide when you need the shortest explanation of what belongs in `/guard/receipts`, `/guard/changes`, and `/guard/history`.
+
+## Start with receipts
+
+Receipts are the latest proof objects Guard synced. Open `/guard/receipts` first when you want to know:
+
+- what Guard saw most recently
+- which decisions just landed
+- whether sync is actually producing evidence
+
+Receipts answer “what happened now?”
+
+## Open changes when something drifted
+
+The Changes route exists for approved artifacts that no longer match the last trusted state.
+
+Open `/guard/changes` when you need to answer:
+
+- what changed after approval
+- which artifact now needs another decision
+- which item should be reviewed before someone retries it elsewhere
+
+Changes answer “what needs a decision now?”
+
+## Use history for longer-term context
+
+History is where you go after the immediate queue is understood.
+
+Open `/guard/history` when you need:
+
+- a longer timeline for one artifact or trust pattern
+- older receipt evidence
+- proof that the same drift pattern keeps repeating
+
+History answers “has this happened before?”
+
+## Recommended operator loop
+
+1. check Receipts for the latest evidence
+2. open Changes when a current decision is needed
+3. move to History only when the short queue needs longer context
+4. update policy or alerts after a repeated pattern becomes obvious
+
+## See it in product
+
+- [Guard receipts](https://hol.org/guard/receipts)
+- [Guard changes](https://hol.org/guard/changes)
+- [Guard history](https://hol.org/guard/history)
+
+## Next guides
+
+- [Inventory, ABOM, and artifact detail](./inventory-abom-and-artifact-detail.md)
+- [Alerts, watchlists, and advisories](./alerts-watchlists-and-advisories.md)
+- [Exceptions and expiring windows](./exceptions-and-expiring-windows.md)

--- a/docs/libraries/ai-plugin-scanner/guard/team-policy-and-delegated-approvals.md
+++ b/docs/libraries/ai-plugin-scanner/guard/team-policy-and-delegated-approvals.md
@@ -1,0 +1,60 @@
+---
+title: Team policy and delegated approvals
+---
+
+# Team policy and delegated approvals
+
+Use this guide when Guard is no longer just a personal safety layer and needs one shared operating model for a team or managed workspace.
+
+## What a team policy pack controls
+
+`/guard/policy` is where Guard becomes less repetitive for operators.
+
+A shared team policy pack can hold:
+
+- per-harness defaults such as watch, ask, or protect
+- allowed publishers
+- blocked publishers
+- blocked domains
+- blocked artifacts
+- alert channel defaults
+
+The point is not more settings. The point is one reusable source of truth.
+
+## Why delegated approvals matter
+
+`/guard/agents` is the route where managed work stops depending on whichever human happened to be at one machine.
+
+Delegated approvals matter when:
+
+- workspaces need a shared approval queue
+- agents should not bypass Guard policy
+- one operator needs to review work started somewhere else
+
+## Recommended rollout order
+
+1. validate local Guard decisions first
+2. sync receipts so the team can see the same evidence
+3. define the shared policy pack
+4. move repeated review work into delegated approvals
+5. keep exceptions time-bound instead of turning them into policy
+
+## What good looks like
+
+A healthy team Guard setup usually has:
+
+- one shared default policy
+- a clear owner path for delegated approvals
+- very few long-lived exceptions
+- alerts that follow policy, not personal inbox habits
+
+## See it in product
+
+- [Guard policy](https://hol.org/guard/policy)
+- [Guard agents](https://hol.org/guard/agents)
+
+## Next guides
+
+- [Exceptions and expiring windows](./exceptions-and-expiring-windows.md)
+- [Alerts, watchlists, and advisories](./alerts-watchlists-and-advisories.md)
+- [Guard Cloud command center](./guard-cloud-command-center.md)

--- a/docs/libraries/ai-plugin-scanner/overview.md
+++ b/docs/libraries/ai-plugin-scanner/overview.md
@@ -62,6 +62,17 @@ Start with these Guard guides:
 - [OpenCode harness](./guard/opencode-harness.md)
 - [Testing and validation](./guard/testing-and-validation.md)
 
+When local Guard is already working and you want the signed-in operating model:
+
+- [Guard Cloud command center](./guard/guard-cloud-command-center.md)
+- [Devices and shared trust memory](./guard/devices-and-shared-trust.md)
+- [Inventory, ABOM, and artifact detail](./guard/inventory-abom-and-artifact-detail.md)
+- [Receipts, changes, and history](./guard/receipts-changes-and-history.md)
+- [Alerts, watchlists, and advisories](./guard/alerts-watchlists-and-advisories.md)
+- [Team policy and delegated approvals](./guard/team-policy-and-delegated-approvals.md)
+- [Exceptions and expiring windows](./guard/exceptions-and-expiring-windows.md)
+- [Billing, credits, and plans](./guard/billing-credits-and-plans.md)
+
 ## plugin-scanner
 
 `plugin-scanner` is the CI and maintainer-facing quality suite. It scans plugin manifests, marketplace metadata, skills, MCP configuration, apps, assets, and repository security posture. It can work against a single plugin or auto-detect supported plugin ecosystems inside a repository root.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -425,6 +425,22 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'category',
+              label: 'Guard Cloud',
+              collapsible: true,
+              collapsed: true,
+              items: [
+                'libraries/ai-plugin-scanner/guard/guard-cloud-command-center',
+                'libraries/ai-plugin-scanner/guard/devices-and-shared-trust',
+                'libraries/ai-plugin-scanner/guard/inventory-abom-and-artifact-detail',
+                'libraries/ai-plugin-scanner/guard/receipts-changes-and-history',
+                'libraries/ai-plugin-scanner/guard/alerts-watchlists-and-advisories',
+                'libraries/ai-plugin-scanner/guard/team-policy-and-delegated-approvals',
+                'libraries/ai-plugin-scanner/guard/exceptions-and-expiring-windows',
+                'libraries/ai-plugin-scanner/guard/billing-credits-and-plans',
+              ],
+            },
+            {
+              type: 'category',
               label: 'plugin-scanner',
               collapsible: true,
               collapsed: true,


### PR DESCRIPTION
## Summary
- add a new Guard Cloud docs cluster covering the signed-in command center, devices, inventory, receipts, alerts, policy, exceptions, and billing workflows
- improve internal linking from existing local Guard guides into the signed-in Guard Cloud operating model
- extend the AI Plugin Scanner overview and canonical sidebar so Guard Cloud intent is crawlable and discoverable

## Verification
- pnpm run build