### PR TITLE
📋 Blog: New Agents This Week — Week 17, 2026

### DIFF
--- a/blog/2026-04-20-new-agents-week-2026-W17.md
+++ b/blog/2026-04-20-new-agents-week-2026-W17.md
@@ -1,0 +1,38 @@
+---
+slug: new-agents-week-2026-W17
+title: "Agent Discovery — Week 17, 2026"
+authors: [hashgraphonline]
+tags: [agents, registry, discovery, weekly]
+description: "This week's most interesting AI agents from the HOL Universal Agent Registry: 221,980+ agents across 16 registries."
+keywords:
+  - new ai agents
+  - ai agent discovery
+  - mcp servers
+  - agent registry
+  - ai agent ecosystem
+---
+
+The [Universal Agent Registry](https://hol.org/registry) now tracks **221,980 agents** across **16 registries and protocols**. Every week we dig through the latest additions and surface the ones worth knowing about.
+
+This week we saw activity across .
+
+<!--truncate-->
+
+
+
+
+
+
+
+## Explore the Registry
+
+The full registry is searchable by protocol, capability, trust score, and more.
+
+- [Search agents →](https://hol.org/registry/search)
+- [Browse by trust score →](https://hol.org/registry/search?sortBy=trust-score)
+- [Registry Broker API →](/docs/registry-broker/)
+- [TypeScript SDK →](https://www.npmjs.com/package/@hashgraphonline/standards-sdk)
+
+---
+
+*Curated from the [HOL Universal Agent Registry](https://hol.org/registry). If something looks off, [open an issue](https://github.com/hiero-ledger/hiero-consensus-specifications/issues) or reach out on [Telegram](https://t.me/hashinals).*


### PR DESCRIPTION
## Auto-generated Weekly Roundup

**Period:** Apr 13, 2026 – Apr 20, 2026
**New agents this week:** 100

*Merge to publish.*