### PR TITLE
docs(guard): add init first-run flow

### DIFF
--- a/docs/libraries/ai-plugin-scanner/guard/get-started.md
+++ b/docs/libraries/ai-plugin-scanner/guard/get-started.md
@@ -23,37 +23,45 @@ pipx install hol-guard
 
 ## The everyday flow
 
-1. Detect the harnesses Guard can manage on this machine.
+1. Run the guided first-install flow.
+
+   ```bash
+   hol-guard init
+   ```
+
+   `hol-guard init` opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts the Guard Cloud connect flow when you want shared history, and runs desktop notification setup so approval prompts can reach you outside the terminal.
+
+2. Use the manual discovery path only when you want to inspect each setup step yourself.
 
    ```bash
    hol-guard bootstrap
    ```
 
-2. Install Guard in front of the harness you use most.
+3. Install Guard in front of the harness you use most when you are not using `hol-guard init`.
 
    ```bash
    hol-guard install codex
    ```
 
-3. Record a baseline once before you trust the current artifact set.
+4. Record a baseline once before you trust the current artifact set.
 
    ```bash
    hol-guard run codex --dry-run
    ```
 
-4. Launch through Guard after that.
+5. Launch through Guard after that.
 
    ```bash
    hol-guard run codex
    ```
 
-5. If Guard cannot pause inline, resolve the queued request in the local approval center.
+6. If Guard cannot pause inline, resolve the queued request in the local approval center.
 
    ```bash
    hol-guard approvals
    ```
 
-6. Inspect receipts, diffs, and current managed state.
+7. Inspect receipts, diffs, and current managed state.
 
    ```bash
    hol-guard receipts

--- a/docs/libraries/ai-plugin-scanner/guard/get-started.md
+++ b/docs/libraries/ai-plugin-scanner/guard/get-started.md
@@ -29,15 +29,15 @@ pipx install hol-guard
    hol-guard init
    ```
 
-   `hol-guard init` opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts the Guard Cloud connect flow when you want shared history, and runs desktop notification setup so approval prompts can reach you outside the terminal.
+   `hol-guard init` opens the local dashboard, discovers supported harnesses, installs managed commands, optionally connects to Guard Cloud for shared history, and configures desktop notifications so approval prompts reach you outside the terminal.
 
-2. Use the manual discovery path only when you want to inspect each setup step yourself.
+2. **Alternative:** Use the manual discovery path if you prefer to inspect each setup step individually.
 
    ```bash
    hol-guard bootstrap
    ```
 
-3. Install Guard in front of the harness you use most when you are not using `hol-guard init`.
+3. **Manual path:** If you skipped `hol-guard init`, install Guard in front of the harness you use most.
 
    ```bash
    hol-guard install codex


### PR DESCRIPTION
## Summary
- update HOL Guard get-started docs to make hol-guard init the guided first-install path
- document local dashboard launch, harness discovery/install, optional Guard Cloud connect, and desktop notification setup
- keep manual bootstrap/install/run flow as fallback for users who want step-by-step control

## Verification
- pnpm run build (passes; existing broken-link warnings remain outside this change)
- python3 docs assertion for hol-guard init and desktop notification copy
- git diff --check